### PR TITLE
Adding django-libsass fixes "django_libsass.SassCompiler: command not…

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,3 +3,4 @@ pytest-django
 pytest-cov
 pytest-xdist
 flake8
+django-libsass

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,4 +3,3 @@ pytest-django
 pytest-cov
 pytest-xdist
 flake8
-django-libsass

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ cookiecutter
 psycopg2cffi
 raven==5.0.0
 markdown
+django-libsass


### PR DESCRIPTION
… found" error.