### PR TITLE
Add certifi to suppress urllib3 SSL warnings.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ psycopg2cffi
 raven==5.0.0
 markdown
 django-libsass
+certifi


### PR DESCRIPTION
See https://urllib3.readthedocs.org/en/latest/security.html#insecureplatformwarning