### PR TITLE
add health URL

### DIFF
--- a/molo/core/tests/test_views.py
+++ b/molo/core/tests/test_views.py
@@ -73,3 +73,8 @@ class TestPages(TestCase):
         self.assertContains(
             response,
             'Your Mind Page 1 Lorem ipsum dolor sit amet')
+
+    def test_health(self):
+        response = self.client.get('/health/')
+        self.assertEquals(
+            response.status_code, 200)

--- a/molo/core/urls.py
+++ b/molo/core/urls.py
@@ -6,5 +6,11 @@ urlpatterns = patterns(
         r'^locale/(?P<locale>[\w\-\_]+)/$',
         'molo.core.views.locale_set',
         name='locale_set'
-    )
+    ),
+
+    url(
+        r'^health/$',
+        'molo.core.views.health',
+        name='health'
+    ),
 )

--- a/molo/core/views.py
+++ b/molo/core/views.py
@@ -1,3 +1,4 @@
+from django.http import HttpResponse
 from django.shortcuts import redirect
 from django.utils.translation import LANGUAGE_SESSION_KEY
 
@@ -5,3 +6,7 @@ from django.utils.translation import LANGUAGE_SESSION_KEY
 def locale_set(request, locale):
     request.session[LANGUAGE_SESSION_KEY] = locale
     return redirect('/')
+
+
+def health(request):
+    return HttpResponse(status=200)


### PR DESCRIPTION
All applications built with molo will be behind a proxy server or load balancer that checks whether or not the application is able to respond to requests. The proxy servers can be configured to check a specific URL to check for the applications "health". If the application does not respond to health requests it will not received any HTTP traffic. We default to the health URL being "/health/" in most of our applications.

- [x] Add a `/health/` URL to `urls.py`
- [x] Link it to a view function in `views.py`
- [x] Have the view function returning an empty `HTTPResponse()` with a `200` status code.
- [x] Write a test for it.

Technically speaking for "health" checks this is really an inadequate test because maybe the database server is unavailable but then the application still says everything is perfectly happy.

We're not ignoring those issues but delaying them until we have this base setup covered first.
