### PR TITLE
Provide tools for allowing packaged templates to be unpacked in the projects template dir.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,4 +1,3 @@
 [run]
-omit = molo/core/migrations/*
+omit = molo/core/migrations/*,molo/core/cookiecutter/*
 source= molo/
-

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ logs/*.log
 db.sqlite3
 docs/_build
 .DS_Store
+/htmlcov/

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ python:
   - "2.7"
   - "pypy"
 env:
-  - COVERAGE=true TEST_RUNNER="py.test --cov molo --ds=testapp.settings --verbose molo"
-  - COVERAGE=false TEST_RUNNER="py.test --ds=testapp.settings --verbose molo"
+  - COVERAGE=true TEST_RUNNER="py.test --cov molo"
+  - COVERAGE=false TEST_RUNNER="py.test"
 matrix:
   exclude:
     - python: "pypy"

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,9 @@ env:
 matrix:
   exclude:
     - python: "pypy"
-      env: COVERAGE=true TEST_RUNNER="py.test --cov molo --ds=testapp.settings --verbose molo"
+      env: COVERAGE=true TEST_RUNNER="py.test --cov molo"
     - python: "2.7"
-      env: COVERAGE=false TEST_RUNNER="py.test --ds=testapp.settings --verbose molo"
+      env: COVERAGE=false TEST_RUNNER="py.test"
 cache:
   directories:
     - $HOME/.pip-cache/

--- a/README.rst
+++ b/README.rst
@@ -98,6 +98,37 @@ To create your own custom settings add a ``local.py`` file in the ``settings``
 folder. The ``settings/dev.py`` will automatically include those settings
 for your local development environment.
 
+Unpacking Templates from Packages
+---------------------------------
+
+Sometimes a package's existing templates simply are not enough and need
+some amount of customization. Use the ``unpack-templates`` command in the
+scaffolded application to unpack a package's templates in your application's
+templates directory::
+
+   $ molo scaffold testapp \
+   >   --require=molo.profiles \
+   >   --include=molo.profiles ^profiles/
+   $ pip install -e testapp
+   ...
+
+You'll see the default templates that ``molo.core`` ships with available in
+the ``templates`` directory::
+
+   $ ls testapp/testapp/templates
+   404.html  500.html  base.html core
+
+Now we unpack the ``profiles`` templates directory from the ``molo.profiles``
+package into the ``testapp`` package template directory::
+
+   $ molo unpack-templates molo.profiles testapp
+   $ ls testapp/testapp/templates
+   404.html  500.html  base.html core profiles
+
+The format is::
+
+   $ molo unpack-templates <source package> <target package>
+
 Writing tests
 -------------
 

--- a/molo/core/scripts/tests/test_cli.py
+++ b/molo/core/scripts/tests/test_cli.py
@@ -107,3 +107,28 @@ class TestCli(TestCase):
                 'include': (('bar', 'baz'),),
             }
         })
+
+    def test_unpack_templates_bad_source(self):
+        from molo.core.scripts import cli
+        runner = CliRunner()
+        result = runner.invoke(cli.unpack_templates, ['molo.core', 'testapp'])
+        self.assertTrue(
+            'molo.core does not have a templates directory' in result.output)
+
+    @patch('molo.core.scripts.cli.get_package')
+    @patch('molo.core.scripts.cli.get_template_dirs')
+    @patch('shutil.copytree')
+    def test_unpack(self, mock_copytree, mock_get_template_dirs,
+                    mock_get_package):
+        package = pkg_resources.get_distribution('molo.core')
+        mock_get_package.return_value = package
+        mock_get_template_dirs.return_value = ['foo']
+        mock_copytree.return_value = True
+
+        from molo.core.scripts import cli
+        runner = CliRunner()
+        runner.invoke(cli.unpack_templates, ['app1', 'app2'])
+
+        mock_copytree.assert_called_with(
+            pkg_resources.resource_filename('molo.core', 'templates/foo'),
+            pkg_resources.resource_filename('molo.core', 'templates/foo'))

--- a/molo/core/scripts/tests/test_cli.py
+++ b/molo/core/scripts/tests/test_cli.py
@@ -3,6 +3,7 @@ import pkg_resources
 
 from mock import patch
 
+from click import UsageError
 from click.testing import CliRunner
 
 
@@ -132,3 +133,11 @@ class TestCli(TestCase):
         mock_copytree.assert_called_with(
             pkg_resources.resource_filename('molo.core', 'templates/foo'),
             pkg_resources.resource_filename('molo.core', 'templates/foo'))
+
+    def test_get_package(self):
+        from molo.core.scripts.cli import get_package
+        self.assertRaisesRegexp(
+            UsageError, 'molo.foo is not installed.', get_package, 'molo.foo')
+        self.assertRaisesRegexp(
+            UsageError, 'molo.core does not have a templates directory.',
+            get_package, 'molo.core')

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,4 +3,4 @@ exclude = ve,docs,molo/core/migrations/*,molo/core/cookiecutter
 ignore = F403
 
 [pytest]
-addopts = --doctest-modules --verbose --ignore=molo/core/cookiecutter
+addopts = --doctest-modules --verbose --ignore=molo/core/cookiecutter --ds=testapp.settings molo


### PR DESCRIPTION
This makes template work for FEDs much easier.
The generate idea is the following:
```bash
$ molo unpack-templates molo.profiles
```
Which would copy all of the stuff in `molo.profiles`s `templates` directory into the scaffolded applications' templates directory.