### PR TITLE
Remove first_published_at ordering from articles

### DIFF
--- a/molo/core/models.py
+++ b/molo/core/models.py
@@ -98,8 +98,7 @@ class SectionPage(Page):
             "and all its descendants"))
 
     def articles(self):
-        return ArticlePage.objects.live().order_by(
-            '-first_published_at').child_of(self)
+        return ArticlePage.objects.live().child_of(self)
 
     def sections(self):
         return SectionPage.objects.live().child_of(self)

--- a/molo/core/tests/test_models.py
+++ b/molo/core/tests/test_models.py
@@ -22,7 +22,7 @@ class TestModels(TestCase):
         # most recent first
         section = SectionPage.objects.get(slug='your-mind-subsection')
         self.assertEquals(
-            section.articles()[0].title, article2.title)
+            section.articles()[0].title, article1.title)
 
         # swap published date
         article1.first_published_at = now + timedelta(hours=4)


### PR DESCRIPTION
This is so the ordering as part of the wagtail backend is honoured and behaves as expected from a user experience perspective.