### PR TITLE
core urls are not defined correctly

### DIFF
--- a/molo/core/cookiecutter/scaffold/{{cookiecutter.directory}}/{{cookiecutter.app_name}}/urls.py
+++ b/molo/core/cookiecutter/scaffold/{{cookiecutter.directory}}/{{cookiecutter.app_name}}/urls.py
@@ -23,6 +23,7 @@ else:
     urlpatterns = patterns('', )
 
 urlpatterns += patterns(
+    '',
     url(r'^django-admin/', include(admin.site.urls)),
     url(r'^admin/', include(wagtailadmin_urls)),
     url(r'^documents/', include(wagtaildocs_urls)),

--- a/molo/core/tests/test_views.py
+++ b/molo/core/tests/test_views.py
@@ -110,6 +110,4 @@ class TestPages(TestCase, MoloTestCaseMixin):
         self.client.login(username='testuser', password='password')
 
         response = self.client.get(reverse('admin:index'))
-        print response
-        self.assertEquals(
-            response.status_code, 200)
+        self.assertEquals(response.status_code, 200)

--- a/molo/core/tests/test_views.py
+++ b/molo/core/tests/test_views.py
@@ -2,6 +2,9 @@ import json
 import pytest
 
 from django.test import TestCase
+from django.contrib.auth.models import User
+from django.core.urlresolvers import reverse
+
 from molo.core.tests.base import MoloTestCaseMixin
 
 
@@ -98,5 +101,15 @@ class TestPages(TestCase, MoloTestCaseMixin):
 
     def test_health(self):
         response = self.client.get('/health/')
+        self.assertEquals(
+            response.status_code, 200)
+
+    def test_issue_with_django_admin_not_loading(self):
+        User.objects.create_superuser(
+            username='testuser', password='password', email='test@email.com')
+        self.client.login(username='testuser', password='password')
+
+        response = self.client.get(reverse('admin:index'))
+        print response
         self.assertEquals(
             response.status_code, 200)


### PR DESCRIPTION
The url [definitions](https://github.com/praekelt/molo/blob/develop/molo/core/cookiecutter/scaffold/%7B%7Bcookiecutter.directory%7D%7D/%7B%7Bcookiecutter.app_name%7D%7D/urls.py#L25-L26) should start with `patterns('',..)`