### PR TITLE
Create comparison view for package versions

### DIFF
--- a/molo/core/cookiecutter/scaffold/{{cookiecutter.directory}}/{{cookiecutter.app_name}}/static/css/_admin_css.scss
+++ b/molo/core/cookiecutter/scaffold/{{cookiecutter.directory}}/{{cookiecutter.app_name}}/static/css/_admin_css.scss
@@ -1,0 +1,12 @@
+.versions{
+  table, th, td {
+      border: 1px solid black;
+  }
+  th, td {
+      padding: 5px;
+      font-size: 15px;
+  }
+  th {
+      text-align: left;
+  }
+}

--- a/molo/core/cookiecutter/scaffold/{{cookiecutter.directory}}/{{cookiecutter.app_name}}/static/css/_admin_css.scss
+++ b/molo/core/cookiecutter/scaffold/{{cookiecutter.directory}}/{{cookiecutter.app_name}}/static/css/_admin_css.scss
@@ -1,12 +1,22 @@
 .versions{
+  color: black;
   table, th, td {
       border: 1px solid black;
   }
   th, td {
       padding: 5px;
-      font-size: 15px;
+      font-size: 14px;
   }
   th {
       text-align: left;
+  }
+  .latest{
+    color: #20C320;
+  }
+  .plugin{
+    font-weight: bold;
+  }
+  .not-installed{
+    color: orange;
   }
 }

--- a/molo/core/cookiecutter/scaffold/{{cookiecutter.directory}}/{{cookiecutter.app_name}}/templates/admin/versions.html
+++ b/molo/core/cookiecutter/scaffold/{{cookiecutter.directory}}/{{cookiecutter.app_name}}/templates/admin/versions.html
@@ -18,14 +18,14 @@
   </tr>
   {% for name,pypi_version,curent_version,compare in plugins_info %}
       <tr>
-        <td>{{name}}</td>
+        <td class="plugin">{{name}}</td>
         <td>{{pypi_version}}</td>
         <td>{{curent_version}}</td>
         {% if pypi_version == curent_version %}
-          <td>{% trans "Latest" %}</td>
+          <td class="latest">{% trans "UpToDate" %}</td>
         {% else %}
           {% if curent_version == "-" %}
-            <td>{% trans "Not installed" %}</td>
+            <td class="not-installed">{% trans "Not installed" %}</td>
           {% else %}
             <td><a href={{compare}}>{% trans "Compare" %}</a></td>
           {% endif %}

--- a/molo/core/cookiecutter/scaffold/{{cookiecutter.directory}}/{{cookiecutter.app_name}}/templates/admin/versions.html
+++ b/molo/core/cookiecutter/scaffold/{{cookiecutter.directory}}/{{cookiecutter.app_name}}/templates/admin/versions.html
@@ -1,20 +1,15 @@
 {% raw %}
 {% extends "base.html" %}
-{% load i18n %}
+{% load i18n static compress %}
+
+{% block extra_css %}
+  {% compress css %}
+    <link rel="stylesheet" type="text/x-scss" href="{% static 'css/_admin_css.scss' %}">
+  {% endcompress %}
+{% endblock %}
+
 {% block content %}
-<style>
-  table, th, td {
-      border: 1px solid black;
-  }
-  th, td {
-      padding: 5px;
-      font-size: 15px;
-  }
-  th {
-      text-align: left;
-  }
-</style>
-<table style="width:100%">
+<table class="versions" style="width:100%">
   <tr>
     <th>{% trans "Package Name" %}</th>
     <th>{% trans "PyPI Version" %}</th>

--- a/molo/core/cookiecutter/scaffold/{{cookiecutter.directory}}/{{cookiecutter.app_name}}/templates/admin/versions.html
+++ b/molo/core/cookiecutter/scaffold/{{cookiecutter.directory}}/{{cookiecutter.app_name}}/templates/admin/versions.html
@@ -1,3 +1,4 @@
+{% raw %}
 {% extends "base.html" %}
 {% load i18n %}
 {% block content %}
@@ -38,3 +39,4 @@
   {% endfor%}
 </table>
 {% endblock %}
+{% endraw %}

--- a/molo/core/cookiecutter/scaffold/{{cookiecutter.directory}}/{{cookiecutter.app_name}}/templates/admin/versions.html
+++ b/molo/core/cookiecutter/scaffold/{{cookiecutter.directory}}/{{cookiecutter.app_name}}/templates/admin/versions.html
@@ -11,12 +11,12 @@
 {% block content %}
 <table class="versions" style="width:100%">
   <tr>
-    <th>{% trans "Package Name" %}</th>
+    <th>{% trans "Plugin" %}</th>
     <th>{% trans "PyPI Version" %}</th>
     <th>{% trans "Runing Version" %}</th>
     <th>{% trans "Status" %}</th>
   </tr>
-  {% for name,pypi_version,curent_version,compare in packages_info %}
+  {% for name,pypi_version,curent_version,compare in plugins_info %}
       <tr>
         <td>{{name}}</td>
         <td>{{pypi_version}}</td>

--- a/molo/core/known_plugins.py
+++ b/molo/core/known_plugins.py
@@ -1,8 +1,8 @@
 
 def known_plugins():
     plugins = [('molo.core', 'Molo'), ('molo.profiles', 'Profiles'),
-                ('molo.commenting', 'Commenting'), ('molo.polls', 'Polls'),
-                ('molo.yourwords', 'YourWords'), ('molo.servicedirectory',
-                'Srvice Directory')]
+               ('molo.commenting', 'Commenting'), ('molo.polls', 'Polls'),
+               ('molo.yourwords', 'YourWords'), ('molo.servicedirectory',
+               'Srvice Directory')]
 
     return plugins

--- a/molo/core/known_plugins.py
+++ b/molo/core/known_plugins.py
@@ -1,0 +1,8 @@
+
+def known_plugins():
+    plugins = [('molo.core', 'Molo'), ('molo.profiles', 'Profiles'),
+                ('molo.commenting', 'Commenting'), ('molo.polls', 'Polls'),
+                ('molo.yourwords', 'YourWords'), ('molo.servicedirectory',
+                'Srvice Directory')]
+
+    return plugins

--- a/molo/core/templates/versions/versions.html
+++ b/molo/core/templates/versions/versions.html
@@ -1,0 +1,40 @@
+{% extends "base.html" %}
+{% load i18n %}
+{% block content %}
+<style>
+  table, th, td {
+      border: 1px solid black;
+  }
+  th, td {
+      padding: 5px;
+      font-size: 15px;
+  }
+  th {
+      text-align: left;
+  }
+</style>
+<table style="width:100%">
+  <tr>
+    <th>{% trans "Package Name" %}</th>
+    <th>{% trans "PyPI Version" %}</th>
+    <th>{% trans "Runing Version" %}</th>
+    <th>{% trans "Status" %}</th>
+  </tr>
+  {% for name,pypi_version,curent_version,compare in packages_info %}
+      <tr>
+        <td>{{name}}</td>
+        <td>{{pypi_version}}</td>
+        <td>{{curent_version}}</td>
+        {% if pypi_version == curent_version %}
+          <td>{% trans "Latest" %}</td>
+        {% else %}
+          {% if curent_version == "-" %}
+            <td>{% trans "Not installed" %}</td>
+          {% else %}
+            <td><a href={{compare}}>{% trans "Compare" %}</a></td>
+          {% endif %}
+        {% endif %}
+      </tr>
+  {% endfor%}
+</table>
+{% endblock %}

--- a/molo/core/tests/test_views.py
+++ b/molo/core/tests/test_views.py
@@ -111,3 +111,10 @@ class TestPages(TestCase, MoloTestCaseMixin):
 
         response = self.client.get(reverse('admin:index'))
         self.assertEquals(response.status_code, 200)
+
+    def test_versions_comparison(self):
+        response = self.client.get(reverse('versions'))
+        print response
+        self.assertContains(
+            response,
+            'Molo')

--- a/molo/core/tests/test_views.py
+++ b/molo/core/tests/test_views.py
@@ -114,7 +114,6 @@ class TestPages(TestCase, MoloTestCaseMixin):
 
     def test_versions_comparison(self):
         response = self.client.get(reverse('versions'))
-        print response
         self.assertContains(
             response,
             'Molo')

--- a/molo/core/urls.py
+++ b/molo/core/urls.py
@@ -13,4 +13,8 @@ urlpatterns = patterns(
         'molo.core.views.health',
         name='health'
     ),
+    url(
+        r'^versions/$',
+        'molo.core.views.versions',
+        name='versions'),
 )

--- a/molo/core/views.py
+++ b/molo/core/views.py
@@ -1,8 +1,11 @@
+import pkg_resources
+import requests
+
 from django.http import HttpResponse
 from django.shortcuts import redirect, render
 from django.utils.translation import LANGUAGE_SESSION_KEY
-import pkg_resources
-import requests
+
+from molo.core.known_plugins import known_plugins
 
 
 def locale_set(request, locale):
@@ -16,38 +19,34 @@ def health(request):
 
 def versions(request):
     comparison_url = "https://github.com/praekelt/%s/compare/%s...%s"
-    packages = [('molo.core', 'Molo'), ('molo.profiles', 'Profiles'),
-                ('molo.commenting', 'Commenting'), ('molo.polls', 'Polls'),
-                ('molo.yourwords', 'YourWords'), ('molo.servicedirectory',
-                'Srvice Directory')]
-    packages_info = []
-    for package in packages:
+    plugins_info = []
+    for plugin in known_plugins():
         try:
-            package_version = (
-                pkg_resources.get_distribution(package[0])).version
+            plugin_version = (
+                pkg_resources.get_distribution(plugin[0])).version
 
-            pypi_version = get_pypi_version(package[0])
+            pypi_version = get_pypi_version(plugin[0])
 
-            if package[0] == 'molo.core':
+            if plugin[0] == 'molo.core':
                 compare_versions_link = comparison_url % (
-                    'molo', package_version, pypi_version)
+                    'molo', plugin_version, pypi_version)
             else:
                 compare_versions_link = comparison_url % (
-                    package[0], package_version, pypi_version)
+                    plugin[0], plugin_version, pypi_version)
 
-            packages_info.append((package[1], pypi_version,
-                                  package_version, compare_versions_link))
+            plugins_info.append((plugin[1], pypi_version,
+                                 plugin_version, compare_versions_link))
         except:
-            pypi_version = get_pypi_version(package[0])
-            packages_info.append((package[1], pypi_version, "-",
+            pypi_version = get_pypi_version(plugin[0])
+            plugins_info.append((plugin[1], pypi_version, "-",
                                  ""))
 
     return render(request, 'admin/versions.html', {
-        'packages_info': packages_info,
+        'plugins_info': plugins_info,
     })
 
 
-def get_pypi_version(package_name):
+def get_pypi_version(plugin_name):
     url = "https://pypi.python.org/pypi/%s/json"
-    content = requests.get(url % package_name).json()
+    content = requests.get(url % plugin_name).json()
     return content.get('info').get('version')

--- a/molo/core/views.py
+++ b/molo/core/views.py
@@ -49,7 +49,5 @@ def versions(request):
 
 def get_pypi_version(package_name):
     url = "https://pypi.python.org/pypi/%s/json"
-    content = (requests.get(url % package_name)).content
-    content = content[((content.find('version')) + 11):]
-    version = content[:content.find('"')]
-    return version
+    content = requests.get(url % package_name).json()
+    return content.get('info').get('version')

--- a/molo/core/views.py
+++ b/molo/core/views.py
@@ -18,7 +18,8 @@ def versions(request):
     comparison_url = "https://github.com/praekelt/%s/compare/%s...%s"
     packages = [('molo.core', 'Molo'), ('molo.profiles', 'Profiles'),
                 ('molo.commenting', 'Commenting'), ('molo.polls', 'Polls'),
-                ('molo.yourwords', 'YourWords')]
+                ('molo.yourwords', 'YourWords'), ('molo.servicedirectory',
+                'Srvice Directory')]
     packages_info = []
     for package in packages:
         try:
@@ -41,7 +42,7 @@ def versions(request):
             packages_info.append((package[1], pypi_version, "-",
                                  ""))
 
-    return render(request, 'versions/versions.html', {
+    return render(request, 'admin/versions.html', {
         'packages_info': packages_info,
     })
 

--- a/molo/core/views.py
+++ b/molo/core/views.py
@@ -1,6 +1,8 @@
 from django.http import HttpResponse
-from django.shortcuts import redirect
+from django.shortcuts import redirect, render
 from django.utils.translation import LANGUAGE_SESSION_KEY
+import pkg_resources
+import requests
 
 
 def locale_set(request, locale):
@@ -10,3 +12,43 @@ def locale_set(request, locale):
 
 def health(request):
     return HttpResponse(status=200)
+
+
+def versions(request):
+    comparison_url = "https://github.com/praekelt/%s/compare/%s...%s"
+    packages = [('molo.core', 'Molo'), ('molo.profiles', 'Profiles'),
+                ('molo.commenting', 'Commenting'), ('molo.polls', 'Polls'),
+                ('molo.yourwords', 'YourWords')]
+    packages_info = []
+    for package in packages:
+        try:
+            package_version = (
+                pkg_resources.get_distribution(package[0])).version
+
+            pypi_version = get_pypi_version(package[0])
+
+            if package[0] == 'molo.core':
+                compare_versions_link = comparison_url % (
+                    'molo', package_version, pypi_version)
+            else:
+                compare_versions_link = comparison_url % (
+                    package[0], package_version, pypi_version)
+
+            packages_info.append((package[1], pypi_version,
+                                  package_version, compare_versions_link))
+        except:
+            pypi_version = get_pypi_version(package[0])
+            packages_info.append((package[1], pypi_version, "-",
+                                 ""))
+
+    return render(request, 'versions/versions.html', {
+        'packages_info': packages_info,
+    })
+
+
+def get_pypi_version(package_name):
+    url = "https://pypi.python.org/pypi/%s/json"
+    content = (requests.get(url % package_name)).content
+    content = content[((content.find('version')) + 11):]
+    version = content[:content.find('"')]
+    return version

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ certifi
 dj-database-url
 django-cas-ng
 django-mptt
+requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ dj-database-url
 django-cas-ng
 django-mptt
 requests
+responses


### PR DESCRIPTION
At the moment we have to manually go check the version of the plugin on PyPI and check the version that we are currently running. There is no good way of keeping track of this.

The solutions is to build a view that displays the PyPI version as well as the version we are currently running, side-by-side and a comparison of the two version if they are not the same.