### PR TITLE
Travis intermittently fails to npm install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ install:
   - pip install "Django >=1.8,<1.9"
   - pip install -r requirements-dev.txt --cache-dir $HOME/.pip-cache/
   - pip install -e . --cache-dir $HOME/.pip-cache/
-  - '[[ -z $NODE ]] || (cd client; npm install)'
+  - '[[ -z $NODE ]] || (cd client; travis_retry npm install)'
 script:
   - flake8 molo
   - molo scaffold testapp


### PR DESCRIPTION
Seems like a [known issue](https://github.com/travis-ci/travis-ci/issues/3130). Might be worth working around it with a `travis_retry`.