### PR TITLE
Work around react-collapse focus issue

### DIFF
--- a/client/src/components/collapse.js
+++ b/client/src/components/collapse.js
@@ -1,0 +1,16 @@
+import ReactCollapse from 'react-collapse';
+
+
+export default class Collapse extends ReactCollapse {
+  componentWillMount() {
+    super.componentWillMount();
+
+    // On the first render, react-collapse renders without using react-motion,
+    // then uses react-motion from then on. This seems to be causing react to
+    // think we are rendering a new element, rather than updating an element,
+    // so `<input>`s in the collapse component will lose focus. Overriding
+    // `renderStatic` makes react-collapse always use react-motion when
+    // rendering.
+    this.renderStatic = false;
+  }
+}

--- a/client/src/views/git-importer/components/choose-site/index.js
+++ b/client/src/views/git-importer/components/choose-site/index.js
@@ -8,9 +8,10 @@ const ChooseSite = (d) => (
     <input
       type="text"
       className="c-choose-site__input"
-      placeholder="Enter a site to import (e.g. foo.bar.unicore.io)"
       value={d.siteUrl}
-      onChange={e => d.actions.changeSiteUrl(e.target.value)} />
+      onChange={e => d.actions.changeSiteUrl(e.target.value)}
+      placeholder="Enter a site to import (e.g. foo.bar.unicore.io)"
+      autoFocus />
 
     {when(inputHasError(d.status), () => (
     <p className="c-choose-site__input-error error-message">

--- a/client/src/views/git-importer/components/git-importer/index.js
+++ b/client/src/views/git-importer/components/git-importer/index.js
@@ -1,6 +1,6 @@
 import React, { PropTypes } from 'react';
-import Collapse from 'react-collapse';
 import classNames from 'classnames';
+import Collapse from 'src/components/collapse';
 import ChooseSite from 'src/views/git-importer/components/choose-site';
 import ChooseMain from 'src/views/git-importer/components/choose-main';
 import ChooseLanguages from 'src/views/git-importer/components/choose-languages';


### PR DESCRIPTION
On the first render, react-collapse renders without using react-motion, then uses react-motion from then on. This seems to be causing react to think we are rendering a new element, rather than updating an element, so `<input>`s in the collapse component will lose focus.