### PR TITLE
Show validation errors for import in import UI

### DIFF
--- a/client/src/views/git-importer/actions.js
+++ b/client/src/views/git-importer/actions.js
@@ -101,7 +101,18 @@ export function toggleLanguageChosen(id) {
 
 export function importContent(repos, languages, api=httpApi) {
   return dispatch => Promise.resolve()
-    .then(() => importContentBusy())
+    .then(() => importContentChecking())
+    .then(dispatch)
+    .then(() => api.checkContent(repos, languages))
+    .then(({errors}) => !errors.length
+      ? importContentHandleValid(dispatch, repos, languages, api)
+      : importContentHandleInvalid(dispatch, errors, repos, languages, api));
+}
+
+
+function importContentHandleValid(dispatch, repos, languages, api) {
+  return Promise.resolve()
+    .then(() => importContentStarting())
     .then(dispatch)
     .then(() => api.importContent(repos, languages))
     .then(() => importContentStarted())
@@ -109,13 +120,33 @@ export function importContent(repos, languages, api=httpApi) {
 }
 
 
-function importContentBusy() {
-  return {type: 'IMPORT_CONTENT/BUSY'};
+function importContentHandleInvalid(dispatch, errors, repos, languages, api) {
+  return Promise.resolve(errors)
+    .then(importContentInvalid)
+    .then(dispatch);
+}
+
+
+function importContentChecking() {
+  return {type: 'IMPORT_CONTENT/CHECKING'};
+}
+
+
+function importContentStarting() {
+  return {type: 'IMPORT_CONTENT/STARTING'};
 }
 
 
 function importContentStarted() {
   return {type: 'IMPORT_CONTENT/STARTED'};
+}
+
+
+function importContentInvalid(errors) {
+  return {
+    type: 'IMPORT_CONTENT/INVALID',
+    payload: {errors}
+  };
 }
 
 

--- a/client/src/views/git-importer/components/choose-languages/index.js
+++ b/client/src/views/git-importer/components/choose-languages/index.js
@@ -49,7 +49,7 @@ function checkButtonText(status) {
     case 'CHECK_CONTENT_COMPLETE':
       return `No errors found`;
 
-    case 'CHECK_CONTENT_ERROR':
+    case 'CHECK_CONTENT_INVALID':
       return `Errors found`;
 
     default:
@@ -60,27 +60,30 @@ function checkButtonText(status) {
 
 function importButtonText(status) {
   switch (status) {
-    case 'IMPORT_CONTENT_BUSY':
+    case 'IMPORT_CONTENT_CHECKING':
+      return `Checking for errors...`;
+
+    case 'IMPORT_CONTENT_STARTING':
       return `Starting import...`;
 
     case 'IMPORT_CONTENT_STARTED':
       return `Import started`;
 
+    case 'IMPORT_CONTENT_INVALID':
+      return `Errors found`;
+
     default:
-      return `Import`;
+      return `Check and import content`;
   }
 }
 
 
 function checkButtonClasses(status) {
   switch (status) {
-    case 'CHECK_CONTENT_BUSY':
-      return 'o-button c-choose-languages__check';
-
     case 'CHECK_CONTENT_COMPLETE':
       return 'o-button o-button--success c-choose-languages__check';
 
-    case 'CHECK_CONTENT_ERROR':
+    case 'CHECK_CONTENT_INVALID':
       return 'o-button o-button--failure c-choose-languages__check';
 
     default:
@@ -91,11 +94,11 @@ function checkButtonClasses(status) {
 
 function importButtonClasses(status) {
   switch (status) {
-    case 'IMPORT_CONTENT_BUSY':
-      return 'o-button c-choose-languages__import';
-
     case 'IMPORT_CONTENT_STARTED':
       return 'o-button o-button--success c-choose-languages__import';
+
+    case 'IMPORT_CONTENT_INVALID':
+      return 'o-button o-button--failure c-choose-languages__import';
 
     default:
       return 'o-button c-choose-languages__import';

--- a/client/src/views/git-importer/reducers.js
+++ b/client/src/views/git-importer/reducers.js
@@ -97,10 +97,27 @@ export default function gitImporter(state, action) {
         })
       });
 
-    case 'IMPORT_CONTENT/BUSY':
+    case 'IMPORT_CONTENT/CHECKING':
       return conj(state, {
         ui: conj(state.ui, {
-          status: 'IMPORT_CONTENT_BUSY'
+          status: 'IMPORT_CONTENT_CHECKING'
+        })
+      });
+
+    case 'IMPORT_CONTENT/STARTING':
+      return conj(state, {
+        ui: conj(state.ui, {
+          status: 'IMPORT_CONTENT_STARTING'
+        })
+      });
+
+    case 'IMPORT_CONTENT/INVALID':
+      return conj(state, {
+        ui: conj(state.ui, {
+          status: 'IMPORT_CONTENT_INVALID'
+        }),
+        data: conj(state.data, {
+          errors: action.payload.errors
         })
       });
 
@@ -122,7 +139,7 @@ export default function gitImporter(state, action) {
       return conj(state, {
         ui: conj(state.ui, {
           status: action.payload.errors.length
-            ? 'CHECK_CONTENT_ERROR'
+            ? 'CHECK_CONTENT_INVALID'
             : 'CHECK_CONTENT_COMPLETE'
         }),
         data: conj(state.data, {

--- a/client/tests/views/git-importer/components/choose-languages.test.js
+++ b/client/tests/views/git-importer/components/choose-languages.test.js
@@ -109,22 +109,36 @@ describe(`ChooseLanguages`, () => {
       .to.be.true;
   });
 
-  it(`should change import button to a busy button when busy`, () => {
+  it(`should change import button to a checking button when checking`, () => {
     const state = fixtures('git-importer');
     state.status = 'IDLE';
 
     let el = draw(state);
     let button = el.find('.c-choose-languages__import');
-    expect(button.text()).to.equal('Import');
+    expect(button.text()).to.equal('Check and import content');
     expect(button.prop('disabled')).to.be.false;
 
-    state.status = 'IMPORT_CONTENT_BUSY';
-
+    state.status = 'IMPORT_CONTENT_CHECKING';
     el = draw(state);
 
     button = el.find('.c-choose-languages__import');
-    expect(button.text()).to.equal('Starting import...');
+    expect(button.text()).to.equal('Checking for errors...');
     expect(button.prop('disabled')).to.be.true;
+  });
+
+  it(`should change import button to a starting button when starting`, () => {
+    const state = fixtures('git-importer');
+    state.status = 'IDLE';
+
+    let el = draw(state);
+    let button = el.find('.c-choose-languages__import');
+    expect(button.text()).to.equal('Check and import content');
+
+    state.status = 'IMPORT_CONTENT_STARTING';
+
+    el = draw(state);
+    button = el.find('.c-choose-languages__import');
+    expect(button.text()).to.equal('Starting import...');
   });
 
   it(`should change import button to a completed button when complete`, () => {
@@ -133,13 +147,28 @@ describe(`ChooseLanguages`, () => {
 
     let el = draw(state);
     let button = el.find('.c-choose-languages__import');
-    expect(button.text()).to.equal('Import');
+    expect(button.text()).to.equal('Check and import content');
 
     state.status = 'IMPORT_CONTENT_STARTED';
 
     el = draw(state);
     button = el.find('.c-choose-languages__import');
     expect(button.text()).to.equal('Import started');
+  });
+
+  it(`should change import button to an error button on error`, () => {
+    const state = fixtures('git-importer');
+    state.status = 'IDLE';
+
+    let el = draw(state);
+    let button = el.find('.c-choose-languages__import');
+    expect(button.text()).to.equal('Check and import content');
+
+    state.status = 'IMPORT_CONTENT_INVALID';
+
+    el = draw(state);
+    button = el.find('.c-choose-languages__import');
+    expect(button.text()).to.equal('Errors found');
   });
 
   it(`should disable the import button if the status is not
@@ -157,7 +186,7 @@ describe(`ChooseLanguages`, () => {
     button = el.find('.c-choose-languages__import');
     expect(button.prop('disabled')).to.be.false;
 
-    state.status = 'CHECK_CONTENT_ERROR';
+    state.status = 'CHECK_CONTENT_INVALID';
 
     el = draw(state);
     button = el.find('.c-choose-languages__import');
@@ -204,7 +233,7 @@ describe(`ChooseLanguages`, () => {
     let button = el.find('.c-choose-languages__check');
     expect(button.text()).to.equal('Check for errors');
 
-    state.status = 'CHECK_CONTENT_ERROR';
+    state.status = 'CHECK_CONTENT_INVALID';
 
     el = draw(state);
     button = el.find('.c-choose-languages__check');
@@ -219,7 +248,7 @@ describe(`ChooseLanguages`, () => {
     let button = el.find('.c-choose-languages__check');
     expect(button.prop('disabled')).to.be.false;
 
-    state.status = 'CHECK_CONTENT_ERROR';
+    state.status = 'CHECK_CONTENT_INVALID';
 
     el = draw(state);
     button = el.find('.c-choose-languages__check');

--- a/client/tests/views/git-importer/reducers.test.js
+++ b/client/tests/views/git-importer/reducers.test.js
@@ -322,19 +322,63 @@ describe(`gitImporter`, () => {
     });
   });
 
-  describe(`IMPORT_CONTENT/BUSY`, () => {
-    it("should change the ui state to busy", () => {
+  describe(`IMPORT_CONTENT/CHECKING`, () => {
+    it("should change the ui state to checking", () => {
       const state = fixtures('state');
       state.ui.status = 'IDLE';
 
       expect(gitImporter(state, {
-          type: 'IMPORT_CONTENT/BUSY'
+          type: 'IMPORT_CONTENT/CHECKING'
         }))
         .to.deep.equal(conj(fixtures('state'), {
           ui: conj(state.ui, {
-            status: 'IMPORT_CONTENT_BUSY'
+            status: 'IMPORT_CONTENT_CHECKING'
           })
         }));
+    });
+  });
+
+  describe(`IMPORT_CONTENT/STARTING`, () => {
+    it("should change the ui state to starting", () => {
+      const state = fixtures('state');
+      state.ui.status = 'IDLE';
+
+      expect(gitImporter(state, {
+          type: 'IMPORT_CONTENT/STARTING'
+        }))
+        .to.deep.equal(conj(fixtures('state'), {
+          ui: conj(state.ui, {
+            status: 'IMPORT_CONTENT_STARTING'
+          })
+        }));
+    });
+  });
+
+  describe(`IMPORT_CONTENT/INVALID`, () => {
+    it("should change the ui state and errors", () => {
+      const state = fixtures('state');
+      state.ui.status = 'IDLE';
+
+      expect(gitImporter(state, {
+        type: 'IMPORT_CONTENT/INVALID',
+        payload: {
+          errors: [{
+            type: 'foo',
+            details: {bar: 'baz'}
+          }]
+        }
+      }))
+      .to.deep.equal(conj(fixtures('state'), {
+        ui: conj(state.ui, {
+          status: 'IMPORT_CONTENT_INVALID'
+        }),
+        data: conj(state.data, {
+          errors: [{
+            type: 'foo',
+            details: {bar: 'baz'}
+          }]
+        })
+      }));
     });
   });
 
@@ -401,7 +445,7 @@ describe(`gitImporter`, () => {
       }))
       .to.deep.equal(conj(fixtures('state'), {
         ui: conj(state.ui, {
-          status: 'CHECK_CONTENT_ERROR'
+          status: 'CHECK_CONTENT_INVALID'
         }),
         data: conj(state.data, {
           errors: [{


### PR DESCRIPTION
At the moment we only show errors if users click 'Check for errors', not 'Import'.