### PR TITLE
add key to session for use with GTM

### DIFF
--- a/molo/core/cookiecutter/scaffold/{{cookiecutter.directory}}/{{cookiecutter.app_name}}/settings/base.py
+++ b/molo/core/cookiecutter/scaffold/{{cookiecutter.directory}}/{{cookiecutter.app_name}}/settings/base.py
@@ -98,6 +98,7 @@ MIDDLEWARE_CLASSES = [
     'wagtailmodeladmin.middleware.ModelAdminMiddleware',
 
     'molo.core.middleware.AdminLocaleMiddleware',
+    'molo.core.middleware.NoScriptGASessionMiddleware',
 ]
 
 TEMPLATES = [

--- a/molo/core/cookiecutter/scaffold/{{cookiecutter.directory}}/{{cookiecutter.app_name}}/templates/base.html
+++ b/molo/core/cookiecutter/scaffold/{{cookiecutter.directory}}/{{cookiecutter.app_name}}/templates/base.html
@@ -78,7 +78,7 @@
 
         {% if settings.core.SiteSettings.ga_tag_manager %}
         <!-- Google Tag Manager -->
-        <noscript><iframe src="//www.googletagmanager.com/ns.html?id={{settings.core.SiteSettings.ga_tag_manager}}"
+        <noscript><iframe src="//www.googletagmanager.com/ns.html?id={{settings.core.SiteSettings.ga_tag_manager}}&client_session_id={{request.session.MOLO_GA_SESSION_FOR_NOSCRIPT}}"
         height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
         <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
         new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],

--- a/molo/core/middleware.py
+++ b/molo/core/middleware.py
@@ -1,3 +1,4 @@
+import uuid
 
 from django.http import HttpResponseForbidden
 from django.views.defaults import permission_denied
@@ -51,7 +52,14 @@ class Custom403Middleware(object):
 class AdminLocaleMiddleware(object):
     """Ensures that the admin locale doesn't change with user selection"""
     def process_request(self, request):
-
         if request.path.startswith('/admin/') or \
            request.path.startswith('/django-admin/'):
             activate(settings.ADMIN_LANGUAGE_CODE)
+
+
+class NoScriptGASessionMiddleware(object):
+    """Store a unique session key for use with GTM"""
+    def process_request(self, request):
+        if 'MOLO_GA_SESSION_FOR_NOSCRIPT' not in request.session:
+            request.session[
+                'MOLO_GA_SESSION_FOR_NOSCRIPT'] = uuid.uuid4().hex


### PR DESCRIPTION
In order to make use of the [GTM noscript functionality](http://www.lunametrics.com/blog/2015/03/23/gtm-iframe-no-javascript/), we need to be able to supply a session based Client ID.

In this implementation, we're just setting a key in the session if it doesn't exist using middleware.
We then pass the key to GTM in the `<noscript>` block