### PR TITLE
Elasticsearch highlighting

### DIFF
--- a/molo/core/cookiecutter/scaffold/{{cookiecutter.directory}}/{{cookiecutter.app_name}}/templates/search/search_results.html
+++ b/molo/core/cookiecutter/scaffold/{{cookiecutter.directory}}/{{cookiecutter.app_name}}/templates/search/search_results.html
@@ -13,16 +13,32 @@
       <a href="{% pageurl page %}">
         <div class="nav">
           <h6>{{ancestor.title}}</h6>
-          <h3>{{page.title}}</h3>
-          <p>{{page.subtitle}}</p>
+          {% if page.title_highlight %}
+              <h3>{{page.title_highlight|safe}}</h3>
+          {% else %}
+              <h3>{{page.title}}</h3>
+          {% endif %}
+          {% if page.subtitle_highlight %}
+              <p>{{page.subtitle_highlight|safe}}</p>
+          {% else %}
+              <p>{{page.subtitle}}</p>
+          {% endif %}
         </div>
       </a>
     {% else %}
       <a href="{% pageurl page %}">
         <div class="nav">
           <h6>{{parent_section.title}}</h6>
-          <h3>{{page.title}}</h3>
-          <p>{{page.subtitle}}</p>
+          {% if page.title_highlight %}
+              <h3>{{page.title_highlight|safe}}</h3>
+          {% else %}
+              <h3>{{page.title}}</h3>
+          {% endif %}
+          {% if page.subtitle_highlight %}
+              <p>{{page.subtitle_highlight|safe}}</p>
+          {% else %}
+              <p>{{page.subtitle}}</p>
+          {% endif %}
         </div>
       </a>
     {% endif %}

--- a/molo/core/cookiecutter/scaffold/{{cookiecutter.directory}}/{{cookiecutter.app_name}}/templates/search/search_results.html
+++ b/molo/core/cookiecutter/scaffold/{{cookiecutter.directory}}/{{cookiecutter.app_name}}/templates/search/search_results.html
@@ -9,39 +9,29 @@
   </div>
   {% for page in search_results %}
     {% with parent_section=page.get_parent_section ancestor=page.get_parent_section.get_ancestors.last %}
-    {% if ancestor.sectionpage.image %}
       <a href="{% pageurl page %}">
         <div class="nav">
-          <h6>{{ancestor.title}}</h6>
+          {% if ancestor.sectionpage.image %}
+              <h6>{{ancestor.title}}</h6>
+          {% else %}
+              <h6>{{parent_section.title}}</h6>
+          {% endif %}
           {% if page.title_highlight %}
               <h3>{{page.title_highlight|safe}}</h3>
           {% else %}
               <h3>{{page.title}}</h3>
           {% endif %}
-          {% if page.subtitle_highlight %}
-              <p>{{page.subtitle_highlight|safe}}</p>
+          {% if page.subtitle_highlight or page.body_highlight %}
+              {% if page.subtitle_highlight %}
+                  <p>{{page.subtitle_highlight|safe}}</p>
+              {% elif page.body_highlight %}
+                  <p>{{page.body_highlight|safe}}</p>
+              {% endif %}
           {% else %}
               <p>{{page.subtitle}}</p>
           {% endif %}
         </div>
       </a>
-    {% else %}
-      <a href="{% pageurl page %}">
-        <div class="nav">
-          <h6>{{parent_section.title}}</h6>
-          {% if page.title_highlight %}
-              <h3>{{page.title_highlight|safe}}</h3>
-          {% else %}
-              <h3>{{page.title}}</h3>
-          {% endif %}
-          {% if page.subtitle_highlight %}
-              <p>{{page.subtitle_highlight|safe}}</p>
-          {% else %}
-              <p>{{page.subtitle}}</p>
-          {% endif %}
-        </div>
-      </a>
-    {% endif %}
     {% endwith %}
   {% endfor %}
 

--- a/molo/core/views.py
+++ b/molo/core/views.py
@@ -36,6 +36,16 @@ def search(request, results_per_page=10):
         results = ArticlePage.objects.filter(pk__in=results)
         results = results.live().search(search_query)
 
+        # At the moment only ES backends have highlight API.
+        if hasattr(results, 'highlight'):
+            results = results.highlight(
+                fields={
+                    'title': {},
+                    'subtitle': {},
+                },
+                require_field_match=False
+            )
+
         Query.get(search_query).add_hit()
     else:
         results = ArticlePage.objects.none()

--- a/molo/core/views.py
+++ b/molo/core/views.py
@@ -42,6 +42,7 @@ def search(request, results_per_page=10):
                 fields={
                     'title': {},
                     'subtitle': {},
+                    'body': {},
                 },
                 require_field_match=False
             )

--- a/molo/core/wagtailsearch/backends/elasticsearch.py
+++ b/molo/core/wagtailsearch/backends/elasticsearch.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, unicode_literals
 
 import json
 
+from django.contrib.contenttypes.models import ContentType
 from django.db import models
 from django.utils.crypto import get_random_string
 from django.utils.six.moves.urllib.parse import urlparse
@@ -395,6 +396,38 @@ class ElasticsearchSearchQuery(BaseSearchQuery):
 
 
 class ElasticsearchSearchResults(BaseSearchResults):
+    def __init__(self, *args, **kwargs):
+        super(ElasticsearchSearchResults, self).__init__(*args, **kwargs)
+        self.highlight_params = {}
+
+    def highlight(self, **kwargs):
+        # It's possible to pass list of dicts and dict as the fields param
+        fields = kwargs.get('fields', [])
+        if isinstance(fields, dict):
+            fields = [{k: v} for k, v in fields.items()]
+
+        post_processed_fields = {}
+        for field_def in fields:
+            field_name = field_def.keys()[0] if isinstance(field_def, dict) and len(field_def) else None
+            if field_name:
+                # Use wildcard column name on request. This allows us to query against all content types.
+                # Alternative solution: get all indexed models and add all possible column names into request.
+                field_column_name = '*{}'.format(field_name)
+                post_processed_field_def = {
+                    field_column_name: field_def[field_name]
+                }
+                post_processed_fields[field_name] = post_processed_field_def
+
+        self.highlight_params['fields'] = post_processed_fields
+        self.highlight_params['require_field_match'] = kwargs.get('require_field_match', None)
+        return self
+
+    def _clone(self):
+        new = super(ElasticsearchSearchResults, self)._clone()
+        new.highlight_params = self.highlight_params
+
+        return new
+
     def _get_es_body(self, for_count=False):
         body = {
             'query': self.query.get_query()
@@ -406,7 +439,25 @@ class ElasticsearchSearchResults(BaseSearchResults):
             if sort is not None:
                 body['sort'] = sort
 
+            # Add highlighting into a body, if fields are specified
+            if self.highlight_params.get('fields'):
+                highlight = {
+                    'fields': self.highlight_params['fields'].values(),
+                }
+
+                if self.highlight_params['require_field_match'] is not None:
+                    highlight.update({
+                        'require_field_match': self.highlight_params['require_field_match'],
+                    })
+
+                body['highlight'] = highlight
+
         return body
+
+    def _get_content_type(self, content_type):
+        app_label, model = content_type.rsplit('_', 2)[-2:]
+
+        return ContentType.objects.get_by_natural_key(app_label, model)
 
     def _do_search(self):
         # Params for elasticsearch query
@@ -414,7 +465,7 @@ class ElasticsearchSearchResults(BaseSearchResults):
             index=self.backend.get_index_for_model(self.query.queryset.model).name,
             body=self._get_es_body(),
             _source=False,
-            fields='pk',
+            fields=['pk', 'content_type'],
             from_=self.start,
         )
 
@@ -425,8 +476,19 @@ class ElasticsearchSearchResults(BaseSearchResults):
         # Send to Elasticsearch
         hits = self.backend.es.search(**params)
 
-        # Get pks from results
-        pks = [hit['fields']['pk'][0] for hit in hits['hits']['hits']]
+        pks = []
+        data_by_pk = {}
+        for hit in hits['hits']['hits']:
+            # Get pks from results
+            pk = hit['fields']['pk'][0]
+            pks.append(pk)
+
+            # Get content type
+            data_by_pk.setdefault(pk, {})
+            data_by_pk[pk]['content_type'] = self._get_content_type(hit['fields']['content_type'][0])
+
+            # Get highlight
+            data_by_pk[pk]['highlight'] = hit.get('highlight', {})
 
         # Initialise results dictionary
         results = dict((str(pk), None) for pk in pks)
@@ -434,7 +496,25 @@ class ElasticsearchSearchResults(BaseSearchResults):
         # Find objects in database and add them to dict
         queryset = self.query.queryset.filter(pk__in=pks)
         for obj in queryset:
-            results[str(obj.pk)] = obj
+            str_pk = str(obj.pk)
+
+            fields_to_highlight = self.highlight_params.get('fields', {}).keys()
+            if fields_to_highlight:
+                obj_model = data_by_pk[str_pk]['content_type'].model_class()
+                obj_mapping = self.backend.mapping_class(obj_model)
+                searchable_search_fields = {f.field_name: f for f in obj_model.get_searchable_search_fields()}
+
+                for field_name in fields_to_highlight:
+                    highlighted_field = None
+
+                    field = searchable_search_fields.get(field_name)
+                    if field:
+                        field_column_name = obj_mapping.get_field_column_name(field)
+                        highlighted_field = data_by_pk[str_pk]['highlight'].get(field_column_name, [None])[0]
+
+                    setattr(obj, '{}_highlight'.format(field_name), highlighted_field)
+
+            results[str_pk] = obj
 
         # Return results in order given by Elasticsearch
         return [results[str(pk)] for pk in pks if results[str(pk)]]

--- a/molo/core/wagtailsearch/backends/elasticsearch2.py
+++ b/molo/core/wagtailsearch/backends/elasticsearch2.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, unicode_literals
 
 import inspect
 
+from django.contrib.contenttypes.models import ContentType
 from django.db import models
 
 from wagtail.wagtailsearch.index import FilterField, RelatedFields, SearchField
@@ -129,7 +130,10 @@ class Elasticsearch2SearchQuery(ElasticsearchSearchQuery):
 
 
 class Elasticsearch2SearchResults(ElasticsearchSearchResults):
-    pass
+    def _get_content_type(self, content_type):
+        app_label, model = content_type.split('.')
+
+        return ContentType.objects.get_by_natural_key(app_label.lower(), model.lower())
 
 
 class Elasticsearch2SearchBackend(ElasticsearchSearchBackend):


### PR DESCRIPTION
This PR adds search highlighting for `title` and `subtitle` fields using `<em>` tags.

You can use Elasticsearch 1 with the following settings:

```python
WAGTAILSEARCH_BACKENDS = {
    'default': {
        'BACKEND': 'molo.core.wagtailsearch.backends.elasticsearch',
        'INDEX': '%your_index_name%',
    },
}
```

Or Elasticsearch 2:

```python
WAGTAILSEARCH_BACKENDS = {
    'default': {
        'BACKEND': 'molo.core.wagtailsearch.backends.elasticsearch2',
        'INDEX': '%your_index_name%',
    },
}
```

Here is an example:
<img width="345" alt="screen shot 2016-09-26 at 12 00 25" src="https://cloud.githubusercontent.com/assets/509198/18828522/ef17ae6c-83e0-11e6-90c8-6b74db8c593d.png">