### PR TITLE
Travis: Use a completely separate job for Node stuff

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ script:
   - molo scaffold testapp
   - flake8 testapp
   - pip install -e testapp
-  - pytest --cov
+  - py.test --cov
 after_success:
   - coveralls
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ matrix:
     - python: '2.7'
     # Include a separate job for the node tests
     - language: node_js
-      node_js: node
+      node_js: '6' # LTS version
       cache:
         directories: [client/node_modules]
       before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,26 @@
 sudo: false
 language: python
-python: '2.7'
+
+matrix:
+  include:
+    - python: '2.7'
+    # Include a separate job for the node tests
+    - language: node_js
+      node_js: node
+      cache:
+        directories: [client/node_modules]
+      before_install:
+        - cd client
+      install:
+        - travis_retry npm install
+      script:
+        - npm run ci
+
+      # Clear unused build steps
+      services: []
+      deploy: []
+      after_success: []
+
 services:
   - elasticsearch
   - redis-server
@@ -28,22 +48,3 @@ deploy:
   on:
     tags: true
     all_branches: true
-
-# Include a separate job for the node tests
-matrix:
-  include:
-    - language: node_js
-      node_js: node
-      cache:
-        directories: [client/node_modules]
-      before_install:
-        - cd client
-      install:
-        - travis_retry npm install
-      script:
-        - npm run ci
-
-      # Clear unused build steps
-      services: []
-      deploy: []
-      after_success: []

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,38 +1,24 @@
 sudo: false
 language: python
+python: '2.7'
 services:
   - elasticsearch
   - redis-server
-python:
-  - "2.7"
-env:
-  - TEST_RUNNER="py.test" COVERAGE=true
-  - NODE_VERSION="5.6.0" TEST_RUNNER="cd client; npm run ci" COVERAGE=false
-cache:
-  - pip
-  - directories:
-    - client/node_modules
-before_install:
-  - |
-      if [[ -n "$NODE_VERSION" ]]; then
-        nvm install "$NODE_VERSION"
-        nvm use "$NODE_VERSION"
-      fi
-  - pip install --upgrade pip
+cache: pip
 
+before_install:
+  - pip install --upgrade pip
 install:
   - pip install -r requirements-dev.txt
-  - if [[ "$COVERAGE" == "true" ]]; then pip install coveralls; fi
-  - '[[ -z $NODE_VERSION ]] || (cd client; travis_retry npm install)'
+  - pip install coveralls
 script:
   - flake8 molo
   - molo scaffold testapp
   - flake8 testapp
   - pip install -e testapp
-  - if [[ "$COVERAGE" == "true" ]] && [[ "$TEST_RUNNER" == "py.test" ]]; then COVERAGE_OPT="--cov"; fi
-  - bash -c "$TEST_RUNNER $COVERAGE_OPT"
+  - pytest --cov
 after_success:
-  - if [[ "$COVERAGE" == "true" ]]; then coveralls; fi
+  - coveralls
 deploy:
   provider: pypi
   distributions: sdist bdist_wheel
@@ -42,3 +28,22 @@ deploy:
   on:
     tags: true
     all_branches: true
+
+# Include a separate job for the node tests
+matrix:
+  include:
+    - language: node_js
+      node_js: node
+      cache:
+        directories: [client/node_modules]
+      before_install:
+        - cd client
+      install:
+        - travis_retry npm install
+      script:
+        - npm run ci
+
+      # Clear unused build steps
+      services: []
+      deploy: []
+      after_success: []


### PR DESCRIPTION
* Run node tests in `node_js` Travis environment
* Remove if/else stuff
* Fix npm module caching
* Run against latest Node LTS release

Takes these tests down to < 2 min. That doesn't really matter, though, as the Python tests take _waaay_ longer.