### PR TITLE
Remove pytest-xdist dev dependency

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,5 +3,4 @@ flake8==2.6.2
 pytest==2.9.2
 pytest-cov
 pytest-django==2.9.1
-pytest-xdist
 responses


### PR DESCRIPTION
* Fixes build for now
* pytest-xdist 1.8.0 requires pytest >= 3
* pytest-xdist really only used locally, optionally, and not in Travis