### PR TITLE
handle relative and aboslute image urls when importing image content

### DIFF
--- a/molo/core/api/importers.py
+++ b/molo/core/api/importers.py
@@ -451,24 +451,20 @@ class ImageImporter(BaseImporter):
                         return matching_image
         return None
 
-    def fetch_and_create_image(self, relative_url, image_title):
+    def fetch_and_create_image(self, url, image_title):
         '''
         fetches, creates image object
 
         returns tuple with Image object and context dictionary containing
         request URL
-
-        TODO: handle hosting media on AWS as well
-        this assumes we are self-hosting media content
         '''
 
-        image_media_url = "{}{}".format(self.base_url, relative_url)
         context = {
-            "requested_url": image_media_url,
+            "requested_url": url,
             "foreign_title": image_title,
         }
         try:
-            image_file = requests.get(image_media_url)
+            image_file = requests.get(url)
             local_image = Image(
                 title=image_title,
                 file=ImageFile(
@@ -535,8 +531,16 @@ class ImageImporter(BaseImporter):
                     local_image.id)
             return (local_image, context)
         else:
+            url = img_info['image_url']
+
+            # handle when image_url is relative
+            # assumes that image import means local storage
+            if img_info['image_url'][0] == '/':
+                url = image_media_url = "{}{}".format(
+                    self.base_url, relative_url)
+
             new_image, context = self.fetch_and_create_image(
-                img_info['image_url'],
+                url,
                 img_info["title"].encode('utf-8'))
             # update record keeper
             if self.record_keeper:

--- a/molo/core/api/importers.py
+++ b/molo/core/api/importers.py
@@ -460,7 +460,7 @@ class ImageImporter(BaseImporter):
         '''
 
         context = {
-            "requested_url": url,
+            "file_url": url,
             "foreign_title": image_title,
         }
         try:
@@ -517,11 +517,19 @@ class ImageImporter(BaseImporter):
             img_info["height"],
             img_info["image_hash"])
 
+        file_url = img_info['image_url']
+
+        # handle when image_url is relative
+        # assumes that image import means local storage
+        if img_info['image_url'][0] == '/':
+            file_url = "{}{}".format(
+                self.base_url, img_info['image_url'])
+
         if local_image:
             context = {
                 "local_version_existed": True,
-                "url": "{}{}".format(self.base_url,
-                                     img_info['image_url']),
+                "file_url": file_url,
+                "image_detail_url": image_detail_url,
                 "foreign_title": img_info["title"].encode('utf-8'),
             }
             # update record keeper
@@ -531,16 +539,8 @@ class ImageImporter(BaseImporter):
                     local_image.id)
             return (local_image, context)
         else:
-            url = img_info['image_url']
-
-            # handle when image_url is relative
-            # assumes that image import means local storage
-            if img_info['image_url'][0] == '/':
-                url = image_media_url = "{}{}".format(
-                    self.base_url, relative_url)
-
             new_image, context = self.fetch_and_create_image(
-                url,
+                file_url,
                 img_info["title"].encode('utf-8'))
             # update record keeper
             if self.record_keeper:

--- a/molo/core/api/tests/test_importers.py
+++ b/molo/core/api/tests/test_importers.py
@@ -239,18 +239,19 @@ class TestImageImporter(MoloTestCaseMixin, TestCase):
     @responses.activate
     def test_fetch_and_create_image_new_image(self):
         image_title = "test_title.png"
-        relative_url = "/media/images/SIbomiWV1AQ.original.jpg"
+        url = "{}/media/images/SIbomiWV1AQ.original.jpg".format(
+            self.fake_base_url)
         test_file_path = os.getcwd() + '/molo/core/api/tests/test_image.png'
 
         with open(test_file_path, 'rb') as img1:
             responses.add(
-                responses.GET, '{}{}'.format(self.fake_base_url, relative_url),
+                responses.GET, url,
                 body=img1.read(), status=200,
                 content_type='image/jpeg',
                 stream=True
             )
         result, context = self.importer.fetch_and_create_image(
-            relative_url,
+            url,
             image_title)
 
         self.assertEqual(type(result), Image)
@@ -258,8 +259,8 @@ class TestImageImporter(MoloTestCaseMixin, TestCase):
         self.assertEqual(Image.objects.count(), 1)
 
         self.assertEqual(
-            context["requested_url"],
-            "{}{}".format(self.importer.base_url, relative_url))
+            context["file_url"],
+            url)
 
     @responses.activate
     def test_import_image_raise_exception(self):
@@ -304,7 +305,7 @@ class TestImageImporter(MoloTestCaseMixin, TestCase):
 
         # check that record has been created
         self.assertEqual(
-            context['requested_url'],
+            context['file_url'],
             "{}{}".format(self.fake_base_url, image_file_location))
 
     @responses.activate
@@ -335,7 +336,7 @@ class TestImageImporter(MoloTestCaseMixin, TestCase):
         # Check context
         self.assertTrue(context["local_version_existed"])
         self.assertEqual(
-            context["url"],
+            context["file_url"],
             "{}{}".format(self.fake_base_url, image_file_location))
         self.assertEqual(
             context["foreign_title"],

--- a/molo/core/api/tests/utils.py
+++ b/molo/core/api/tests/utils.py
@@ -106,14 +106,13 @@ def mocked_requests_get(url, *args, **kwargs):
     return MockResponse({}, 404)
 
 
-def mocked_fetch_and_create_image(relative_url, image_title):
+def mocked_fetch_and_create_image(url, image_title):
     image = Image.objects.create(
         title=image_title,
         file=get_test_image_file(),
     )
-    image_media_url = "http://localhost:8000{}".format(relative_url)
     context = {
-        "requested_url": image_media_url,
+        "file_url": url,
         "foreign_title": image_title.encode('utf-8'),
     }
     return (image, context)


### PR DESCRIPTION
Error in Logs:
```
>> ACTION: Importing Image
>> ERROR: Importing Images
| ex_type: <class 'requests.exceptions.ConnectionError'>
| exception: HTTPSConnectionPool(host='qa.tuneme.seed.p16n.orghttps', port=443): Max retries exceeded with url: //tuneme-qa.s3.amazonaws.com/images/Photo_on_2012-04-08_at_13.03.original.jpg (Caused by NewConnectionError('<urllib3.connection.VerifiedHTTPSConnection object at 0x10a850050>: Failed to establish a new connection: [Errno 8] nodename nor servname provided, or not known',))
| foreign_title: Loving
| requested_url: https://qa.tuneme.seed.p16n.orghttps://tuneme-qa.s3.amazonaws.com/images/Photo_on_2012-04-08_at_13.03.original.jpg
----
```

Caused by combining image URL with base URL, regardless of whether the image was stored locally or in AWS.

Solution: When fetching an image, only add base URL when URL is relative.