### PR TITLE
Update image hash when Image file changes

### DIFF
--- a/molo/core/models.py
+++ b/molo/core/models.py
@@ -329,7 +329,11 @@ class ImageInfo(models.Model):
 @receiver(
     post_save, sender=Image, dispatch_uid="create_image_info")
 def create_image_info(sender, instance, **kwargs):
-    ImageInfo.objects.get_or_create(image=instance)
+    image_info, created = ImageInfo.objects.get_or_create(image=instance)
+    # ensure that image info is updated, in the event that an
+    # image is changed e.g. file is changed, prompting change in hash
+    if not created:
+        image_info.save()
 
 
 class ImportableMixin(object):

--- a/molo/core/tests/test_images.py
+++ b/molo/core/tests/test_images.py
@@ -82,3 +82,27 @@ class TestImageInfoObject(MoloTestCaseMixin, TestCase):
 
         self.assertEquals(Image.objects.count(), 0)
         self.assertEquals(ImageInfo.objects.count(), 0)
+
+    def test_image_info_updated_on_file_change(self):
+        file_1 = get_test_image_file(colour='black', size=(100, 100))
+        file_2 = get_test_image_file(colour='white', size=(80, 80))
+
+        image = Image.objects.create(
+            title="Test image",
+            file=file_1,
+        )
+
+        id_ = image.id
+        original_hash = image.image_info.image_hash
+
+        image.file = file_2
+        image.save()
+
+        updated_image = Image.objects.get(id=id_)
+
+        new_hash = updated_image.image_info.image_hash
+
+        self.assertNotEqual(
+            original_hash,
+            new_hash
+        )


### PR DESCRIPTION
When creating an Image for the first time, an ImageInfo object is created as well.
When an image is saved again, it does not update the ImageInfo object. This has the unintended side effect of not updating the image hash when an image file is changed.

This PR rectifies this by saving the associated ImageInfo object when the Image already exists.
