### PR TITLE
Remove question mark from locale links when not needed

### DIFF
--- a/molo/core/models.py
+++ b/molo/core/models.py
@@ -651,12 +651,8 @@ class TranslatablePageMixinNotRoutable(object):
         if main_lang.locale == locale_code:
             translation = parent
 
-        path_components = [
-            component for component in request.path.split('/') if component]
-        if path_components and path_components[-1] != 'noredirect' and \
-                translation and language_rel.language.locale != locale_code:
-            return redirect(
-                '%s?%s' % (translation.url, request.GET.urlencode()))
+        if translation and language_rel.language.locale != locale_code:
+            return redirect(translation.url)
 
         return super(TranslatablePageMixinNotRoutable, self).serve(
             request, *args, **kwargs)

--- a/molo/core/models.py
+++ b/molo/core/models.py
@@ -652,7 +652,10 @@ class TranslatablePageMixinNotRoutable(object):
             translation = parent
 
         if translation and language_rel.language.locale != locale_code:
-            return redirect(translation.url)
+            if request.GET.urlencode():
+                return redirect("{}?{}".format(translation.url, request.GET.urlencode()))
+            else:
+                return redirect(translation.url)
 
         return super(TranslatablePageMixinNotRoutable, self).serve(
             request, *args, **kwargs)

--- a/molo/core/models.py
+++ b/molo/core/models.py
@@ -653,7 +653,8 @@ class TranslatablePageMixinNotRoutable(object):
 
         if translation and language_rel.language.locale != locale_code:
             if request.GET.urlencode():
-                return redirect("{}?{}".format(translation.url, request.GET.urlencode()))
+                return redirect("{}?{}".format(translation.url,
+                                               request.GET.urlencode()))
             else:
                 return redirect(translation.url)
 

--- a/molo/core/templates/patterns/basics/languages/language-list-center.html
+++ b/molo/core/templates/patterns/basics/languages/language-list-center.html
@@ -7,7 +7,7 @@
     <ul class="language-list language-list--standard-center">
       {% for language in languages %}
       <li class="language-list__item language-list__item--standard-center">
-        <a href="{% url 'locale_set' language.locale %}?next={{request.path}}?{{ request.GET.urlencode }}" class="language-list__anchor language-list__anchor-standard-center {% if LANGUAGE_CODE == language.locale %} is-active {% endif %}">
+        <a href="{% url 'locale_set' language.locale %}?next={{request.path}}{% if request.GET.urlencode %}?{{ request.GET.urlencode }}{% endif %}" class="language-list__anchor language-list__anchor-standard-center {% if LANGUAGE_CODE == language.locale %} is-active {% endif %}">
           {{language.locale|language_name_local}}
         </a>
       </li>

--- a/molo/core/templates/patterns/basics/languages/language-list-dropdown.html
+++ b/molo/core/templates/patterns/basics/languages/language-list-dropdown.html
@@ -15,7 +15,7 @@
         <ul class="language-list language-list--dropdown">
           {% for language in languages %}
             <li class="language-list__item language-list__item--dropdown">
-              <a href="{% url 'locale_set' language.locale %}?next={{request.path}}?{{ request.GET.urlencode }}" class="language-list__anchor language-list__anchor-dropdown {% if LANGUAGE_CODE == language.locale %} is-active {% endif %}">
+              <a href="{% url 'locale_set' language.locale %}?next={{request.path}}{% if request.GET.urlencode %}?{{ request.GET.urlencode }}{% endif %}" class="language-list__anchor language-list__anchor-dropdown {% if LANGUAGE_CODE == language.locale %} is-active {% endif %}">
                 {{language.locale|language_name_local}}
               </a>
             </li>

--- a/molo/core/templates/patterns/basics/languages/language-list-dropdown_footer.html
+++ b/molo/core/templates/patterns/basics/languages/language-list-dropdown_footer.html
@@ -13,7 +13,7 @@
         <ul class="language-list language-list--dropdown language-list--dropdown-footer">
           {% for language in languages %}
             <li class="language-list__item language-list__item--dropdown language-list__item--dropdown-footer">
-              <a href="{% url 'locale_set' language.locale %}?next={{request.path}}?{{ request.GET.urlencode }}" class="language-list__anchor language-list__anchor-dropdown language-list__anchor-dropdown-footer {% if LANGUAGE_CODE == language.locale %} is-active {% endif %}">
+              <a href="{% url 'locale_set' language.locale %}?next={{request.path}}{% if request.GET.urlencode %}?{{ request.GET.urlencode }}{% endif %}" class="language-list__anchor language-list__anchor-dropdown language-list__anchor-dropdown-footer {% if LANGUAGE_CODE == language.locale %} is-active {% endif %}">
                 {{language.locale|language_name_local}}
               </a>
             </li>

--- a/molo/core/templates/patterns/basics/languages/language-list-label.html
+++ b/molo/core/templates/patterns/basics/languages/language-list-label.html
@@ -7,7 +7,7 @@
       </li>
       {% for language in languages %}
       <li class="language-list__item language-list__item--with-label">
-        <a href="{% url 'locale_set' language.locale %}?next={{request.path}}?{{ request.GET.urlencode }}" class="language-list__anchor language-list__anchor-with-label {% if LANGUAGE_CODE == language.locale %}is-active{% endif %}">
+        <a href="{% url 'locale_set' language.locale %}?next={{request.path}}{% if request.GET.urlencode %}?{{ request.GET.urlencode }}{% endif %}" class="language-list__anchor language-list__anchor-with-label {% if LANGUAGE_CODE == language.locale %}is-active{% endif %}">
           {{language.locale|language_name_local}}
         </a>
       </li>

--- a/molo/core/templates/patterns/basics/languages/language-list-standard.html
+++ b/molo/core/templates/patterns/basics/languages/language-list-standard.html
@@ -7,7 +7,7 @@
     <ul class="language-list language-list--standard">
       {% for language in languages %}
       <li class="language-list__item language-list__item--standard">
-        <a href="{% url 'locale_set' language.locale %}?next={{request.path}}?{{ request.GET.urlencode }}" class="language-list__anchor language-list__anchor--standard {% if LANGUAGE_CODE == language.locale %} is-active {% endif %}">
+        <a href="{% url 'locale_set' language.locale %}?next={{request.path}}{% if request.GET.urlencode %}?{{ request.GET.urlencode }}{% endif %}" class="language-list__anchor language-list__anchor--standard {% if LANGUAGE_CODE == language.locale %} is-active {% endif %}">
           {{language.locale|language_name_local}}
         </a>
       </li>

--- a/molo/core/templates/patterns/basics/languages/language-list-text_decorated.html
+++ b/molo/core/templates/patterns/basics/languages/language-list-text_decorated.html
@@ -10,7 +10,7 @@
       </li>
       {% for language in languages %}
       <li class="language-list__item language-list__item--text-decorated language-list__item--text-decorated-{{position}}">
-        <a href="{% url 'locale_set' language.locale %}?next={{request.path}}?{{ request.GET.urlencode }}" class="language-list__anchor language-list__anchor-text-decorated language-list__anchor-text-decorated-{{position}} {% if LANGUAGE_CODE == language.locale %} is-active {% endif %}">
+        <a href="{% url 'locale_set' language.locale %}?next={{request.path}}{% if request.GET.urlencode %}?{{ request.GET.urlencode }}{% endif %}" class="language-list__anchor language-list__anchor-text-decorated language-list__anchor-text-decorated-{{position}} {% if LANGUAGE_CODE == language.locale %} is-active {% endif %}">
           {{language.locale|language_name_local}}
         </a>
       </li>

--- a/molo/core/templates/patterns/basics/languages/sp_variations/language-list-center_fixed.html
+++ b/molo/core/templates/patterns/basics/languages/sp_variations/language-list-center_fixed.html
@@ -4,7 +4,7 @@
   <ul class="language-list language-list--standard-center">
   {% for language in languages %}
     <li class="language-list__item language-list__item--standard-center">
-      <a href="{% url 'locale_set' language.locale %}?next={{request.path}}?{{ request.GET.urlencode }}" class="language-list__anchor language-list__anchor-standard-center {% if LANGUAGE_CODE == language.locale %} is-active {% endif %}">
+      <a href="{% url 'locale_set' language.locale %}?next={{request.path}}{% if request.GET.urlencode %}?{{ request.GET.urlencode }}{% endif %}" class="language-list__anchor language-list__anchor-standard-center {% if LANGUAGE_CODE == language.locale %} is-active {% endif %}">
         {{language.locale|language_name_local}}
       </a>
     </li>

--- a/molo/core/tests/test_views.py
+++ b/molo/core/tests/test_views.py
@@ -1129,8 +1129,7 @@ class TestPages(TestCase, MoloTestCaseMixin):
         self.assertContains(response, '&larr;')
 
     def test_pagination_for_translated_articles_in_sections(self):
-        en_articles = self.mk_articles(self.yourmind, count=12)
-        self.mk_articles(self.yourmind, count=3)
+        en_articles = self.mk_articles(self.yourmind, count=15)
 
         for p in en_articles:
             self.mk_article_translation(

--- a/molo/core/tests/test_views.py
+++ b/molo/core/tests/test_views.py
@@ -360,7 +360,7 @@ class TestPages(TestCase, MoloTestCaseMixin):
         response = self.client.get('/')
         self.assertContains(
             response,
-            '<a href="/locale/en/?next=/?" class="language-list__anchor '
+            '<a href="/locale/en/?next=/" class="language-list__anchor '
             'language-list__anchor-with-label is-active">English</a>',
             html=True)
         self.assertContains(
@@ -374,7 +374,7 @@ class TestPages(TestCase, MoloTestCaseMixin):
         response = client.get(self.site2.root_url)
         self.assertContains(
             response,
-            '<a href="/locale/en/?next=/?" class="language-list__anchor '
+            '<a href="/locale/en/?next=/" class="language-list__anchor '
             'language-list__anchor-with-label is-active">English</a>',
             html=True)
         self.assertContains(
@@ -899,13 +899,13 @@ class TestPages(TestCase, MoloTestCaseMixin):
         self.assertRedirects(
             response,
             'http://main-1.localhost:8000/sections'
-            '-main-1/your-mind-in-french/?')
+            '-main-1/your-mind-in-french/')
 
         response = self.client.get('/sections-main-1/your-mind/test-page-0/')
         self.assertRedirects(
             response,
             'http://main-1.localhost:8000/sections-main-1/your-mind/'
-            'test-page-0-in-french/?')
+            'test-page-0-in-french/')
 
         # redirect from translation to main language should also work
         response = self.client.get('/locale/en/')
@@ -913,14 +913,14 @@ class TestPages(TestCase, MoloTestCaseMixin):
         response = self.client.get('/sections-main-1/your-mind-in-french/')
         self.assertRedirects(
             response,
-            'http://main-1.localhost:8000/sections-main-1/your-mind/?')
+            'http://main-1.localhost:8000/sections-main-1/your-mind/')
 
         response = self.client.get('/sections-main-1/your-mind/'
                                    'test-page-0-in-french/')
         self.assertRedirects(
             response,
             'http://main-1.localhost:8000/sections-main-1/your-mind/test-pag'
-            'e-0/?')
+            'e-0/')
 
         # unpublished translation will not result in a redirect
         self.yourmind_fr.unpublish()


### PR DESCRIPTION
See ticket: https://praekeltorg.atlassian.net/browse/GEMMOLO-478

When changing locale, the response page appended a `?` to the end of the URL. This was causing issues with our SEO and instead of messing about with `canonical` tags, this PR should remove instances of `?` without any parameters, from any URL served by the site.