### PR TITLE
Use strings for paths

### DIFF
--- a/molo/core/tests/base.py
+++ b/molo/core/tests/base.py
@@ -83,7 +83,7 @@ class MoloTestCaseMixin(object):
         # Site.objects.all().delete()
         self.site = self.main.get_site()
 
-    def mk_main2(self, title='main2', slug='main2', path=00010002):
+    def mk_main2(self, title='main2', slug='main2', path='4098'):
         self.mk_root()
         main_content_type, created = ContentType.objects.get_or_create(
             model='main', app_label='core')

--- a/molo/core/tests/test_views.py
+++ b/molo/core/tests/test_views.py
@@ -109,7 +109,7 @@ class TestPages(TestCase, MoloTestCaseMixin):
     def test_site_redirect_if_no_languages(self):
         user = User.objects.create_superuser(
             username='testuser', password='password', email='test@email.com')
-        self.mk_main2(title='main3', slug='main3', path=00010003)
+        self.mk_main2(title='main3', slug='main3', path='4099')
         main3_pk = Page.objects.get(title='main3').pk
         main3 = Main.objects.all().last()
         client = Client(HTTP_HOST=main3.get_site().hostname)


### PR DESCRIPTION
I'm not sure why these are octal numbers but I think they should be strings.

The `mk_main()` method creates a Main object with a path as a string.

This improves Python 3 compatibility because octal numbers specified with leading 0s are invalid tokens in Python 3.