### PR TITLE
Run part of the test suite on Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,9 @@ matrix:
       after_success: []
   allow_failures:
     - python: '3.6'
+      env: TEST=molo_lint
+    - python: '3.6'
+      env: TEST=build
 
 services:
   - elasticsearch

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,19 @@
 sudo: false
 language: python
+python:
+  - '2.7'
+
+env:
+  - TEST=molo_lint
+  - TEST=testapp_lint
+  - TEST=build
 
 matrix:
   include:
-    - python: '2.7'
     # Include a separate job for the node tests
     - language: node_js
       node_js: '6' # LTS version
+      env: []
       cache:
         directories: [client/node_modules]
       before_install:
@@ -31,12 +38,7 @@ before_install:
 install:
   - pip install -r requirements-dev.txt
   - pip install coveralls
-script:
-  - flake8 molo
-  - molo scaffold testapp
-  - flake8 testapp
-  - pip install -e testapp
-  - py.test --cov
+script: ./travis.sh
 after_success:
   - coveralls
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ sudo: false
 language: python
 python:
   - '2.7'
+  - '3.6'
 
 env:
   - TEST=molo_lint
@@ -27,6 +28,8 @@ matrix:
       services: []
       deploy: []
       after_success: []
+  allow_failures:
+    - python: '3.6'
 
 services:
   - elasticsearch

--- a/molo/core/scripts/cli.py
+++ b/molo/core/scripts/cli.py
@@ -36,7 +36,7 @@ def unpack_templates(**kwargs):
                 pkg_resources.resource_filename(
                     target_pkg.key, os.path.join('templates', directory))
             )
-        except (OSError,), e:
+        except OSError as e:
             raise click.ClickException(str(e))
 
 

--- a/travis.sh
+++ b/travis.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+set -e # Exit whenever a command fails
+set -x # Output commands run to see them in the Travis interface
+
+function setup_testapp {
+    molo scaffold testapp
+}
+
+if [ "$TEST" == "molo_lint" ]; then
+    flake8 molo
+elif [ "$TEST" == "testapp_lint" ]; then
+    setup_testapp
+    flake8 testapp
+elif [ "$TEST" == "build" ]; then
+    setup_testapp
+    pip install -e testapp
+    py.test --cov
+else
+    echo "The environment variable TEST was not set correctly"
+    exit 1
+fi


### PR DESCRIPTION
This commit splits the Travis build into 3 separate build jobs:

- Running `flake8` on the molo codebase
- Running `flake8` on a new molo app
- Running tests after installing a new molo app

Advantages:

- With one simple change (`except OSError as e`) the `flake8` of the new molo app passes on Python 3. This will make sure we don't introduce any new Python 3 issues on that part of the codebase.
- This might make the build very slightly faster because those 3 jobs can run in parallel rather than sequentially.