### PR TITLE
Remove use of grunticon-lib

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -18,7 +18,7 @@ var gulp              =   require('gulp'),
     pixrem            =   require('gulp-pixrem'),
     svgmin            =   require('gulp-svgmin'),
     del               =   require('del'),
-    grunticon         =   require('grunticon-lib'),
+
     sassPaths = [
         'molo/core/styles/sass/styles.s+(a|c)ss',
         'molo/core/styles/mote.customize/mote.s+(a|c)ss'
@@ -117,8 +117,6 @@ gulp.task('icons', ['clean-icons', 'crush-svgs'], function(done) {
         black: '#000000'
       }
     };
-    var iconsTask = new grunticon(icons, iconsDest, options);
-    iconsTask.process(done);
 });
 
 gulp.task('styles', ['styles:dev', 'styles:prd','stylesAdmin']);

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,16 +4,6 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@filamentgroup/worker-farm": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@filamentgroup/worker-farm/-/worker-farm-1.3.2.tgz",
-      "integrity": "sha1-CTaJSimxbbfntKim7eIfUnD1NLQ=",
-      "dev": true,
-      "requires": {
-        "errno": "0.1.4",
-        "xtend": "4.0.1"
-      }
-    },
     "@gulp-sourcemaps/map-sources": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@gulp-sourcemaps/map-sources/-/map-sources-1.0.0.tgz",
@@ -75,17 +65,6 @@
       "integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw=",
       "dev": true
     },
-    "align-text": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-      "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-      "dev": true,
-      "requires": {
-        "kind-of": "3.2.2",
-        "longest": "1.0.1",
-        "repeat-string": "1.6.1"
-      }
-    },
     "amdefine": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
@@ -137,15 +116,6 @@
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.1.2.tgz",
       "integrity": "sha512-ZpYajIfO0j2cOFTO955KUMIKNmj6zhX8kVztMAxFsDaMwz+9Z9SV0uou2pC9HJqcfpffOsjnbrDMvkNy+9RXPw==",
       "dev": true
-    },
-    "archive-type": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/archive-type/-/archive-type-3.2.0.tgz",
-      "integrity": "sha1-nNnABpV+vpX62tW9YJiUKoE3N/Y=",
-      "dev": true,
-      "requires": {
-        "file-type": "3.9.0"
-      }
     },
     "archy": {
       "version": "1.0.0",
@@ -282,24 +252,11 @@
       "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
       "dev": true
     },
-    "async": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
-      "dev": true
-    },
     "async-each": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
       "integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
       "dev": true
-    },
-    "async-each-series": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/async-each-series/-/async-each-series-1.1.0.tgz",
-      "integrity": "sha1-9C/YFV048hpbjqB8KOBj7RcAsTg=",
-      "dev": true,
-      "optional": true
     },
     "async-foreach": {
       "version": "0.1.3",
@@ -377,116 +334,11 @@
       "integrity": "sha1-5tXqjF2tABMEpwsiY4RH9pyy+Ak=",
       "dev": true
     },
-    "bin-build": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/bin-build/-/bin-build-2.2.0.tgz",
-      "integrity": "sha1-EfjdYfcP/Por3KpbRvXo/t1CIcw=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "archive-type": "3.2.0",
-        "decompress": "3.0.0",
-        "download": "4.4.3",
-        "exec-series": "1.0.3",
-        "rimraf": "2.6.1",
-        "tempfile": "1.1.1",
-        "url-regex": "3.2.0"
-      }
-    },
-    "bin-check": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/bin-check/-/bin-check-2.0.0.tgz",
-      "integrity": "sha1-hvjm9CU4k99g3DFpV/WvAqywWTA=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "executable": "1.1.0"
-      }
-    },
-    "bin-version": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/bin-version/-/bin-version-1.0.4.tgz",
-      "integrity": "sha1-nrSY7m/Xb3q5p8FgQ2+JV5Q1144=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "find-versions": "1.2.1"
-      }
-    },
-    "bin-version-check": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/bin-version-check/-/bin-version-check-2.1.0.tgz",
-      "integrity": "sha1-5OXfKQuQaffRETJAMe/BP90RpbA=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "bin-version": "1.0.4",
-        "minimist": "1.2.0",
-        "semver": "4.3.6",
-        "semver-truncate": "1.1.2"
-      }
-    },
-    "bin-wrapper": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/bin-wrapper/-/bin-wrapper-3.0.2.tgz",
-      "integrity": "sha1-Z9MwYmLksaXy+I7iNGT2plVneus=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "bin-check": "2.0.0",
-        "bin-version-check": "2.1.0",
-        "download": "4.4.3",
-        "each-async": "1.1.1",
-        "lazy-req": "1.1.0",
-        "os-filter-obj": "1.0.3"
-      }
-    },
     "binary-extensions": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.8.0.tgz",
       "integrity": "sha1-SOyNFt9Dd+rl+liEaCSAr02Vx3Q=",
       "dev": true
-    },
-    "bl": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.1.tgz",
-      "integrity": "sha1-ysMo977kVzDUBLaSID/LWQ4XLV4=",
-      "dev": true,
-      "requires": {
-        "readable-stream": "2.3.3"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-          "dev": true,
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
-        }
-      }
     },
     "bless": {
       "version": "4.0.4",
@@ -630,67 +482,6 @@
         "electron-to-chromium": "1.3.21"
       }
     },
-    "buffer-to-vinyl": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/buffer-to-vinyl/-/buffer-to-vinyl-1.1.0.tgz",
-      "integrity": "sha1-APFfruOreh3aLN5tkSG//dB7ImI=",
-      "dev": true,
-      "requires": {
-        "file-type": "3.9.0",
-        "readable-stream": "2.3.3",
-        "uuid": "2.0.3",
-        "vinyl": "1.2.0"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-          "dev": true,
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
-        },
-        "uuid": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
-          "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho=",
-          "dev": true
-        },
-        "vinyl": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
-          "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
-          "dev": true,
-          "requires": {
-            "clone": "1.0.2",
-            "clone-stats": "0.0.1",
-            "replace-ext": "0.0.1"
-          }
-        }
-      }
-    },
     "builtin-modules": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
@@ -746,12 +537,6 @@
       "integrity": "sha1-IMiVdoOY3tX5ikvqtKdsKF3vQdI=",
       "dev": true
     },
-    "capture-stack-trace": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
-      "integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0=",
-      "dev": true
-    },
     "cardinal": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/cardinal/-/cardinal-1.0.0.tgz",
@@ -767,36 +552,6 @@
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
       "dev": true
-    },
-    "caw": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/caw/-/caw-1.2.0.tgz",
-      "integrity": "sha1-/7Im/n78VHKI3GLuPpcHPCEtEDQ=",
-      "dev": true,
-      "requires": {
-        "get-proxy": "1.1.0",
-        "is-obj": "1.0.1",
-        "object-assign": "3.0.0",
-        "tunnel-agent": "0.4.3"
-      },
-      "dependencies": {
-        "tunnel-agent": {
-          "version": "0.4.3",
-          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
-          "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
-          "dev": true
-        }
-      }
-    },
-    "center-align": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
-      "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
-      "dev": true,
-      "requires": {
-        "align-text": "0.1.4",
-        "lazy-cache": "1.0.4"
-      }
     },
     "chalk": {
       "version": "1.1.3",
@@ -1053,13 +808,6 @@
       "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
       "dev": true
     },
-    "console-stream": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/console-stream/-/console-stream-0.1.1.tgz",
-      "integrity": "sha1-oJX+B7IEZZVfL6/Si11yvM2UnUQ=",
-      "dev": true,
-      "optional": true
-    },
     "content-type": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz",
@@ -1105,15 +853,6 @@
           "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "dev": true
         }
-      }
-    },
-    "create-error-class": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
-      "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
-      "dev": true,
-      "requires": {
-        "capture-stack-trace": "1.0.0"
       }
     },
     "cross-spawn": {
@@ -1168,17 +907,6 @@
             "amdefine": "1.0.1"
           }
         }
-      }
-    },
-    "csso": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/csso/-/csso-2.0.0.tgz",
-      "integrity": "sha1-F4tDpEYhIhwndWCG9THgL0KQDug=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "clap": "1.2.3",
-        "source-map": "0.5.6"
       }
     },
     "currently-unhandled": {
@@ -1255,454 +983,6 @@
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
       "dev": true
-    },
-    "decompress": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/decompress/-/decompress-3.0.0.tgz",
-      "integrity": "sha1-rx3VDQbjv8QyRh033hGzjA2ZG+0=",
-      "dev": true,
-      "requires": {
-        "buffer-to-vinyl": "1.1.0",
-        "concat-stream": "1.6.0",
-        "decompress-tar": "3.1.0",
-        "decompress-tarbz2": "3.1.0",
-        "decompress-targz": "3.1.0",
-        "decompress-unzip": "3.4.0",
-        "stream-combiner2": "1.1.1",
-        "vinyl-assign": "1.2.1",
-        "vinyl-fs": "2.4.4"
-      },
-      "dependencies": {
-        "glob": {
-          "version": "5.0.15",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-          "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-          "dev": true,
-          "requires": {
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "2.0.10",
-            "once": "1.3.3",
-            "path-is-absolute": "1.0.1"
-          }
-        },
-        "glob-parent": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
-          "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
-          "dev": true,
-          "requires": {
-            "is-glob": "3.1.0",
-            "path-dirname": "1.0.2"
-          }
-        },
-        "glob-stream": {
-          "version": "5.3.5",
-          "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-5.3.5.tgz",
-          "integrity": "sha1-pVZlqajM3EGRWofHAeMtTgFvrSI=",
-          "dev": true,
-          "requires": {
-            "extend": "3.0.1",
-            "glob": "5.0.15",
-            "glob-parent": "3.1.0",
-            "micromatch": "2.3.11",
-            "ordered-read-streams": "0.3.0",
-            "through2": "0.6.5",
-            "to-absolute-glob": "0.1.1",
-            "unique-stream": "2.2.1"
-          },
-          "dependencies": {
-            "isarray": {
-              "version": "0.0.1",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-              "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-              "dev": true
-            },
-            "readable-stream": {
-              "version": "1.0.34",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-              "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-              "dev": true,
-              "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
-                "isarray": "0.0.1",
-                "string_decoder": "0.10.31"
-              }
-            },
-            "string_decoder": {
-              "version": "0.10.31",
-              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-              "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-              "dev": true
-            },
-            "through2": {
-              "version": "0.6.5",
-              "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-              "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-              "dev": true,
-              "requires": {
-                "readable-stream": "1.0.34",
-                "xtend": "4.0.1"
-              }
-            }
-          }
-        },
-        "graceful-fs": {
-          "version": "4.1.11",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-          "dev": true
-        },
-        "gulp-sourcemaps": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
-          "integrity": "sha1-uG/zSdgBzrVuHZ59x7vLS33uYAw=",
-          "dev": true,
-          "requires": {
-            "convert-source-map": "1.5.0",
-            "graceful-fs": "4.1.11",
-            "strip-bom": "2.0.0",
-            "through2": "2.0.3",
-            "vinyl": "1.2.0"
-          }
-        },
-        "is-extglob": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-          "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-          "dev": true
-        },
-        "is-glob": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
-          "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-          "dev": true,
-          "requires": {
-            "is-extglob": "2.1.1"
-          }
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-          "dev": true
-        },
-        "ordered-read-streams": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz",
-          "integrity": "sha1-cTfmmzKYuzQiR6G77jiByA4v14s=",
-          "dev": true,
-          "requires": {
-            "is-stream": "1.1.0",
-            "readable-stream": "2.3.3"
-          }
-        },
-        "readable-stream": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-          "dev": true,
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
-        },
-        "strip-bom": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-          "dev": true,
-          "requires": {
-            "is-utf8": "0.2.1"
-          }
-        },
-        "strip-bom-stream": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-1.0.0.tgz",
-          "integrity": "sha1-5xRDmFd9Uaa+0PoZlPoF9D/ZiO4=",
-          "dev": true,
-          "requires": {
-            "first-chunk-stream": "1.0.0",
-            "strip-bom": "2.0.0"
-          }
-        },
-        "unique-stream": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.2.1.tgz",
-          "integrity": "sha1-WqADz76Uxf+GbE59ZouxxNuts2k=",
-          "dev": true,
-          "requires": {
-            "json-stable-stringify": "1.0.1",
-            "through2-filter": "2.0.0"
-          }
-        },
-        "vinyl": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
-          "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
-          "dev": true,
-          "requires": {
-            "clone": "1.0.2",
-            "clone-stats": "0.0.1",
-            "replace-ext": "0.0.1"
-          }
-        },
-        "vinyl-fs": {
-          "version": "2.4.4",
-          "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.4.tgz",
-          "integrity": "sha1-vm/zJwy1Xf19MGNkDegfJddTIjk=",
-          "dev": true,
-          "requires": {
-            "duplexify": "3.5.1",
-            "glob-stream": "5.3.5",
-            "graceful-fs": "4.1.11",
-            "gulp-sourcemaps": "1.6.0",
-            "is-valid-glob": "0.3.0",
-            "lazystream": "1.0.0",
-            "lodash.isequal": "4.5.0",
-            "merge-stream": "1.0.1",
-            "mkdirp": "0.5.1",
-            "object-assign": "4.1.1",
-            "readable-stream": "2.3.3",
-            "strip-bom": "2.0.0",
-            "strip-bom-stream": "1.0.0",
-            "through2": "2.0.3",
-            "through2-filter": "2.0.0",
-            "vali-date": "1.0.0",
-            "vinyl": "1.2.0"
-          }
-        }
-      }
-    },
-    "decompress-tar": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/decompress-tar/-/decompress-tar-3.1.0.tgz",
-      "integrity": "sha1-IXx4n5uURQ76rcXF5TeXj8MzxGY=",
-      "dev": true,
-      "requires": {
-        "is-tar": "1.0.0",
-        "object-assign": "2.1.1",
-        "strip-dirs": "1.1.1",
-        "tar-stream": "1.5.4",
-        "through2": "0.6.5",
-        "vinyl": "0.4.6"
-      },
-      "dependencies": {
-        "clone": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
-          "integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8=",
-          "dev": true
-        },
-        "object-assign": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
-          "integrity": "sha1-Q8NuXVaf+OSBbE76i+AtJpZ8GKo=",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "dev": true,
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
-          }
-        },
-        "through2": {
-          "version": "0.6.5",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-          "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-          "dev": true,
-          "requires": {
-            "readable-stream": "1.0.34",
-            "xtend": "4.0.1"
-          }
-        },
-        "vinyl": {
-          "version": "0.4.6",
-          "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
-          "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
-          "dev": true,
-          "requires": {
-            "clone": "0.2.0",
-            "clone-stats": "0.0.1"
-          }
-        }
-      }
-    },
-    "decompress-tarbz2": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/decompress-tarbz2/-/decompress-tarbz2-3.1.0.tgz",
-      "integrity": "sha1-iyOTVoE1X58YnYclag+L3ZbZZm0=",
-      "dev": true,
-      "requires": {
-        "is-bzip2": "1.0.0",
-        "object-assign": "2.1.1",
-        "seek-bzip": "1.0.5",
-        "strip-dirs": "1.1.1",
-        "tar-stream": "1.5.4",
-        "through2": "0.6.5",
-        "vinyl": "0.4.6"
-      },
-      "dependencies": {
-        "clone": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
-          "integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8=",
-          "dev": true
-        },
-        "object-assign": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
-          "integrity": "sha1-Q8NuXVaf+OSBbE76i+AtJpZ8GKo=",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "dev": true,
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
-          }
-        },
-        "through2": {
-          "version": "0.6.5",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-          "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-          "dev": true,
-          "requires": {
-            "readable-stream": "1.0.34",
-            "xtend": "4.0.1"
-          }
-        },
-        "vinyl": {
-          "version": "0.4.6",
-          "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
-          "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
-          "dev": true,
-          "requires": {
-            "clone": "0.2.0",
-            "clone-stats": "0.0.1"
-          }
-        }
-      }
-    },
-    "decompress-targz": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/decompress-targz/-/decompress-targz-3.1.0.tgz",
-      "integrity": "sha1-ssE9+YFmJomRtxXWRH9kLpaW9aA=",
-      "dev": true,
-      "requires": {
-        "is-gzip": "1.0.0",
-        "object-assign": "2.1.1",
-        "strip-dirs": "1.1.1",
-        "tar-stream": "1.5.4",
-        "through2": "0.6.5",
-        "vinyl": "0.4.6"
-      },
-      "dependencies": {
-        "clone": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
-          "integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8=",
-          "dev": true
-        },
-        "object-assign": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
-          "integrity": "sha1-Q8NuXVaf+OSBbE76i+AtJpZ8GKo=",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "dev": true,
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
-          }
-        },
-        "through2": {
-          "version": "0.6.5",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-          "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-          "dev": true,
-          "requires": {
-            "readable-stream": "1.0.34",
-            "xtend": "4.0.1"
-          }
-        },
-        "vinyl": {
-          "version": "0.4.6",
-          "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
-          "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
-          "dev": true,
-          "requires": {
-            "clone": "0.2.0",
-            "clone-stats": "0.0.1"
-          }
-        }
-      }
-    },
-    "decompress-unzip": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/decompress-unzip/-/decompress-unzip-3.4.0.tgz",
-      "integrity": "sha1-YUdbQVIGa74/7hL51inRX+ZHjus=",
-      "dev": true,
-      "requires": {
-        "is-zip": "1.0.0",
-        "read-all-stream": "3.1.0",
-        "stat-mode": "0.2.2",
-        "strip-dirs": "1.1.1",
-        "through2": "2.0.3",
-        "vinyl": "1.2.0",
-        "yauzl": "2.4.1"
-      },
-      "dependencies": {
-        "vinyl": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
-          "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
-          "dev": true,
-          "requires": {
-            "clone": "1.0.2",
-            "clone-stats": "0.0.1",
-            "replace-ext": "0.0.1"
-          }
-        }
-      }
     },
     "deep-defaults": {
       "version": "1.0.4",
@@ -1809,177 +1089,6 @@
       "integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k=",
       "dev": true
     },
-    "directory-colorfy": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/directory-colorfy/-/directory-colorfy-2.2.1.tgz",
-      "integrity": "sha512-NzSHZdHELkLhjfq0Zl7kS9AsnWg3xTEdmB/HSar22gFC4dXQRtl64jVQfDiiMnj/ybsXn5EYllY6X/cyyJlcow==",
-      "dev": true,
-      "requires": {
-        "@filamentgroup/worker-farm": "1.3.2",
-        "fs-extra": "0.6.3",
-        "phantomjs-prebuilt": "2.1.15",
-        "rsvp": "3.0.15"
-      },
-      "dependencies": {
-        "fs-extra": {
-          "version": "0.6.3",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.6.3.tgz",
-          "integrity": "sha1-qhXKVIwD16U+zUuXCCclwRZv/JA=",
-          "dev": true,
-          "requires": {
-            "jsonfile": "1.0.1",
-            "mkdirp": "0.3.5",
-            "ncp": "0.4.2",
-            "rimraf": "2.2.8"
-          }
-        },
-        "jsonfile": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-1.0.1.tgz",
-          "integrity": "sha1-6l7+QLg2kLmGZ2FKc5L8YOhCwN0=",
-          "dev": true
-        },
-        "mkdirp": {
-          "version": "0.3.5",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
-          "integrity": "sha1-3j5fiWHIjHh+4TaN+EmsRBPsqNc=",
-          "dev": true
-        },
-        "rimraf": {
-          "version": "2.2.8",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
-          "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=",
-          "dev": true
-        }
-      }
-    },
-    "directory-encoder": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/directory-encoder/-/directory-encoder-0.9.2.tgz",
-      "integrity": "sha1-IN5NpJUEP0Plx+ITwUBcsFeRR6U=",
-      "dev": true,
-      "requires": {
-        "fs-extra": "1.0.0",
-        "handlebars": "4.0.10",
-        "img-stats": "0.5.2"
-      },
-      "dependencies": {
-        "camelcase": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-          "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
-          "dev": true,
-          "optional": true
-        },
-        "cliui": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-          "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "center-align": "0.1.3",
-            "right-align": "0.1.3",
-            "wordwrap": "0.0.2"
-          }
-        },
-        "fs-extra": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-1.0.0.tgz",
-          "integrity": "sha1-zTzl9+fLYUWIP8rjGR6Yd/hYeVA=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "jsonfile": "2.4.0",
-            "klaw": "1.3.1"
-          }
-        },
-        "graceful-fs": {
-          "version": "4.1.11",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-          "dev": true
-        },
-        "handlebars": {
-          "version": "4.0.10",
-          "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.10.tgz",
-          "integrity": "sha1-PTDHGLCaPZbyPqTMH0A8TTup/08=",
-          "dev": true,
-          "requires": {
-            "async": "1.5.2",
-            "optimist": "0.6.1",
-            "source-map": "0.4.4",
-            "uglify-js": "2.8.29"
-          }
-        },
-        "jsonfile": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
-          "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11"
-          }
-        },
-        "source-map": {
-          "version": "0.4.4",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-          "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-          "dev": true,
-          "requires": {
-            "amdefine": "1.0.1"
-          }
-        },
-        "uglify-js": {
-          "version": "2.8.29",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
-          "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "source-map": "0.5.7",
-            "uglify-to-browserify": "1.0.2",
-            "yargs": "3.10.0"
-          },
-          "dependencies": {
-            "source-map": {
-              "version": "0.5.7",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-              "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "window-size": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
-          "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
-          "dev": true,
-          "optional": true
-        },
-        "wordwrap": {
-          "version": "0.0.2",
-          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-          "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
-          "dev": true,
-          "optional": true
-        },
-        "yargs": {
-          "version": "3.10.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-          "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "camelcase": "1.2.1",
-            "cliui": "2.1.0",
-            "decamelize": "1.2.0",
-            "window-size": "0.1.0"
-          }
-        }
-      }
-    },
     "doctrine": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
@@ -1998,251 +1107,6 @@
         }
       }
     },
-    "download": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/download/-/download-4.4.3.tgz",
-      "integrity": "sha1-qlX9rTktldS2jowr4D4MKqIbqaw=",
-      "dev": true,
-      "requires": {
-        "caw": "1.2.0",
-        "concat-stream": "1.6.0",
-        "each-async": "1.1.1",
-        "filenamify": "1.2.1",
-        "got": "5.7.1",
-        "gulp-decompress": "1.2.0",
-        "gulp-rename": "1.2.2",
-        "is-url": "1.2.2",
-        "object-assign": "4.1.1",
-        "read-all-stream": "3.1.0",
-        "readable-stream": "2.3.3",
-        "stream-combiner2": "1.1.1",
-        "vinyl": "1.2.0",
-        "vinyl-fs": "2.4.4",
-        "ware": "1.3.0"
-      },
-      "dependencies": {
-        "glob": {
-          "version": "5.0.15",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-          "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-          "dev": true,
-          "requires": {
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "2.0.10",
-            "once": "1.3.3",
-            "path-is-absolute": "1.0.1"
-          }
-        },
-        "glob-parent": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
-          "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
-          "dev": true,
-          "requires": {
-            "is-glob": "3.1.0",
-            "path-dirname": "1.0.2"
-          }
-        },
-        "glob-stream": {
-          "version": "5.3.5",
-          "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-5.3.5.tgz",
-          "integrity": "sha1-pVZlqajM3EGRWofHAeMtTgFvrSI=",
-          "dev": true,
-          "requires": {
-            "extend": "3.0.1",
-            "glob": "5.0.15",
-            "glob-parent": "3.1.0",
-            "micromatch": "2.3.11",
-            "ordered-read-streams": "0.3.0",
-            "through2": "0.6.5",
-            "to-absolute-glob": "0.1.1",
-            "unique-stream": "2.2.1"
-          },
-          "dependencies": {
-            "isarray": {
-              "version": "0.0.1",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-              "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-              "dev": true
-            },
-            "readable-stream": {
-              "version": "1.0.34",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-              "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-              "dev": true,
-              "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
-                "isarray": "0.0.1",
-                "string_decoder": "0.10.31"
-              }
-            },
-            "string_decoder": {
-              "version": "0.10.31",
-              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-              "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-              "dev": true
-            },
-            "through2": {
-              "version": "0.6.5",
-              "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-              "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-              "dev": true,
-              "requires": {
-                "readable-stream": "1.0.34",
-                "xtend": "4.0.1"
-              }
-            }
-          }
-        },
-        "graceful-fs": {
-          "version": "4.1.11",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-          "dev": true
-        },
-        "gulp-sourcemaps": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
-          "integrity": "sha1-uG/zSdgBzrVuHZ59x7vLS33uYAw=",
-          "dev": true,
-          "requires": {
-            "convert-source-map": "1.5.0",
-            "graceful-fs": "4.1.11",
-            "strip-bom": "2.0.0",
-            "through2": "2.0.3",
-            "vinyl": "1.2.0"
-          }
-        },
-        "is-extglob": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-          "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-          "dev": true
-        },
-        "is-glob": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
-          "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-          "dev": true,
-          "requires": {
-            "is-extglob": "2.1.1"
-          }
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-          "dev": true
-        },
-        "ordered-read-streams": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz",
-          "integrity": "sha1-cTfmmzKYuzQiR6G77jiByA4v14s=",
-          "dev": true,
-          "requires": {
-            "is-stream": "1.1.0",
-            "readable-stream": "2.3.3"
-          }
-        },
-        "readable-stream": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-          "dev": true,
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
-        },
-        "strip-bom": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-          "dev": true,
-          "requires": {
-            "is-utf8": "0.2.1"
-          }
-        },
-        "strip-bom-stream": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-1.0.0.tgz",
-          "integrity": "sha1-5xRDmFd9Uaa+0PoZlPoF9D/ZiO4=",
-          "dev": true,
-          "requires": {
-            "first-chunk-stream": "1.0.0",
-            "strip-bom": "2.0.0"
-          }
-        },
-        "unique-stream": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.2.1.tgz",
-          "integrity": "sha1-WqADz76Uxf+GbE59ZouxxNuts2k=",
-          "dev": true,
-          "requires": {
-            "json-stable-stringify": "1.0.1",
-            "through2-filter": "2.0.0"
-          }
-        },
-        "vinyl": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
-          "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
-          "dev": true,
-          "requires": {
-            "clone": "1.0.2",
-            "clone-stats": "0.0.1",
-            "replace-ext": "0.0.1"
-          }
-        },
-        "vinyl-fs": {
-          "version": "2.4.4",
-          "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.4.tgz",
-          "integrity": "sha1-vm/zJwy1Xf19MGNkDegfJddTIjk=",
-          "dev": true,
-          "requires": {
-            "duplexify": "3.5.1",
-            "glob-stream": "5.3.5",
-            "graceful-fs": "4.1.11",
-            "gulp-sourcemaps": "1.6.0",
-            "is-valid-glob": "0.3.0",
-            "lazystream": "1.0.0",
-            "lodash.isequal": "4.5.0",
-            "merge-stream": "1.0.1",
-            "mkdirp": "0.5.1",
-            "object-assign": "4.1.1",
-            "readable-stream": "2.3.3",
-            "strip-bom": "2.0.0",
-            "strip-bom-stream": "1.0.0",
-            "through2": "2.0.3",
-            "through2-filter": "2.0.0",
-            "vali-date": "1.0.0",
-            "vinyl": "1.2.0"
-          }
-        }
-      }
-    },
     "duplexer": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
@@ -2256,78 +1120,6 @@
       "dev": true,
       "requires": {
         "readable-stream": "1.1.14"
-      }
-    },
-    "duplexify": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.1.tgz",
-      "integrity": "sha512-j5goxHTwVED1Fpe5hh3q9R93Kip0Bg2KVAt4f8CEYM3UEwYcPSvWbXaUQOzdX/HtiNomipv+gU7ASQPDbV7pGQ==",
-      "dev": true,
-      "requires": {
-        "end-of-stream": "1.4.0",
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.3",
-        "stream-shift": "1.0.0"
-      },
-      "dependencies": {
-        "end-of-stream": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
-          "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
-          "dev": true,
-          "requires": {
-            "once": "1.4.0"
-          }
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true
-        },
-        "once": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-          "dev": true,
-          "requires": {
-            "wrappy": "1.0.2"
-          }
-        },
-        "readable-stream": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-          "dev": true,
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
-        }
-      }
-    },
-    "each-async": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/each-async/-/each-async-1.1.1.tgz",
-      "integrity": "sha1-3uUim98KtrogEqOV4bhpq/iBNHM=",
-      "dev": true,
-      "requires": {
-        "onetime": "1.1.0",
-        "set-immediate-shim": "1.0.1"
       }
     },
     "ecc-jsbn": {
@@ -2440,15 +1232,6 @@
           "integrity": "sha1-XtwETKTrb3gW1Qui/GPiXY/kcH8=",
           "dev": true
         }
-      }
-    },
-    "errno": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
-      "integrity": "sha1-uJbiOp5ei6M4cfyZar02NfyaHH0=",
-      "dev": true,
-      "requires": {
-        "prr": "0.0.0"
       }
     },
     "error-ex": {
@@ -2714,37 +1497,6 @@
         "through": "2.3.8"
       }
     },
-    "exec-buffer": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/exec-buffer/-/exec-buffer-2.0.1.tgz",
-      "integrity": "sha1-ACijG+CxRgth0HX5avRYO54zXqA=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "rimraf": "2.6.1",
-        "tempfile": "1.1.1"
-      }
-    },
-    "exec-series": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/exec-series/-/exec-series-1.0.3.tgz",
-      "integrity": "sha1-bSV6m+rEgqhyx3g7yGFYOfx3FDo=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "async-each-series": "1.1.0",
-        "object-assign": "4.1.1"
-      },
-      "dependencies": {
-        "object-assign": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-          "dev": true,
-          "optional": true
-        }
-      }
-    },
     "execall": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/execall/-/execall-1.0.0.tgz",
@@ -2752,16 +1504,6 @@
       "dev": true,
       "requires": {
         "clone-regexp": "1.0.0"
-      }
-    },
-    "executable": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/executable/-/executable-1.1.0.tgz",
-      "integrity": "sha1-h3mA6REvM5EGbaNyZd562ENKtNk=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "meow": "3.7.0"
       }
     },
     "exit-hook": {
@@ -2802,15 +1544,6 @@
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
       "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
       "dev": true
-    },
-    "extend-shallow": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-      "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-      "dev": true,
-      "requires": {
-        "is-extendable": "0.1.1"
-      }
     },
     "extglob": {
       "version": "0.3.2",
@@ -2905,12 +1638,6 @@
         "pend": "1.2.0"
       }
     },
-    "fg-loadcss": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/fg-loadcss/-/fg-loadcss-1.3.1.tgz",
-      "integrity": "sha1-iTDoIJWfqvuyQoUO7sTy0CWUMMs=",
-      "dev": true
-    },
     "figures": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
@@ -2947,34 +1674,11 @@
         }
       }
     },
-    "file-type": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
-      "integrity": "sha1-JXoHg4TR24CHvESdEH1SpSZyuek=",
-      "dev": true
-    },
     "filename-regex": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
       "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
       "dev": true
-    },
-    "filename-reserved-regex": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-1.0.0.tgz",
-      "integrity": "sha1-5hz4BfDeHJhFZ9A4bcXfUO5a9+Q=",
-      "dev": true
-    },
-    "filenamify": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/filenamify/-/filenamify-1.2.1.tgz",
-      "integrity": "sha1-qfL/0RxQO+0wABUCknI3jx8TZaU=",
-      "dev": true,
-      "requires": {
-        "filename-reserved-regex": "1.0.0",
-        "strip-outer": "1.0.0",
-        "trim-repeated": "1.0.0"
-      }
     },
     "fill-range": {
       "version": "2.2.3",
@@ -3003,19 +1707,6 @@
       "requires": {
         "path-exists": "2.1.0",
         "pinkie-promise": "2.0.1"
-      }
-    },
-    "find-versions": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/find-versions/-/find-versions-1.2.1.tgz",
-      "integrity": "sha1-y96fEuOFdaCvG+G5osXV/Y8Ya2I=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "array-uniq": "1.0.3",
-        "get-stdin": "4.0.1",
-        "meow": "3.7.0",
-        "semver-regex": "1.0.0"
       }
     },
     "findup-sync": {
@@ -4232,15 +2923,6 @@
       "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
       "dev": true
     },
-    "get-proxy": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/get-proxy/-/get-proxy-1.1.0.tgz",
-      "integrity": "sha1-iUhUSRvFkbDxR9euVw9cZ4tyVus=",
-      "dev": true,
-      "requires": {
-        "rc": "1.2.1"
-      }
-    },
     "get-stdin": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
@@ -4262,18 +2944,6 @@
           "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
           "dev": true
         }
-      }
-    },
-    "gifsicle": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/gifsicle/-/gifsicle-3.0.4.tgz",
-      "integrity": "sha1-9Fy17RAWW2ZdySng6TKLbIId+js=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "bin-build": "2.2.0",
-        "bin-wrapper": "3.0.2",
-        "logalot": "2.1.0"
       }
     },
     "glob": {
@@ -4515,76 +3185,6 @@
         }
       }
     },
-    "got": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/got/-/got-5.7.1.tgz",
-      "integrity": "sha1-X4FjWmHkplifGAVp6k44FoClHzU=",
-      "dev": true,
-      "requires": {
-        "create-error-class": "3.0.2",
-        "duplexer2": "0.1.4",
-        "is-redirect": "1.0.0",
-        "is-retry-allowed": "1.1.0",
-        "is-stream": "1.1.0",
-        "lowercase-keys": "1.0.0",
-        "node-status-codes": "1.0.0",
-        "object-assign": "4.1.1",
-        "parse-json": "2.2.0",
-        "pinkie-promise": "2.0.1",
-        "read-all-stream": "3.1.0",
-        "readable-stream": "2.3.3",
-        "timed-out": "3.1.3",
-        "unzip-response": "1.0.2",
-        "url-parse-lax": "1.0.0"
-      },
-      "dependencies": {
-        "duplexer2": {
-          "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
-          "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
-          "dev": true,
-          "requires": {
-            "readable-stream": "2.3.3"
-          }
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-          "dev": true,
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
-        }
-      }
-    },
     "graceful-fs": {
       "version": "3.0.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
@@ -4611,113 +3211,6 @@
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
       "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
       "dev": true
-    },
-    "grunticon-lib": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/grunticon-lib/-/grunticon-lib-1.2.3.tgz",
-      "integrity": "sha1-wLfOvc7OA+78vHAFawHDjonbrUM=",
-      "dev": true,
-      "requires": {
-        "directory-colorfy": "2.2.1",
-        "directory-encoder": "0.9.2",
-        "fg-loadcss": "1.3.1",
-        "fs-extra": "0.16.5",
-        "handlebars": "3.0.3",
-        "lodash": "3.10.1",
-        "merge-defaults": "0.2.1",
-        "svg-to-png": "3.1.2",
-        "uglify-js": "2.8.29",
-        "xmldom": "0.1.27"
-      },
-      "dependencies": {
-        "camelcase": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-          "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
-          "dev": true
-        },
-        "cliui": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-          "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
-          "dev": true,
-          "requires": {
-            "center-align": "0.1.3",
-            "right-align": "0.1.3",
-            "wordwrap": "0.0.2"
-          }
-        },
-        "fs-extra": {
-          "version": "0.16.5",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.16.5.tgz",
-          "integrity": "sha1-GtZh+myGyWCM0bSe/G/Og0k5p1A=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "3.0.11",
-            "jsonfile": "2.4.0",
-            "rimraf": "2.6.1"
-          }
-        },
-        "jsonfile": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
-          "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11"
-          },
-          "dependencies": {
-            "graceful-fs": {
-              "version": "4.1.11",
-              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-              "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "lodash": {
-          "version": "3.10.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
-          "dev": true
-        },
-        "uglify-js": {
-          "version": "2.8.29",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
-          "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
-          "dev": true,
-          "requires": {
-            "source-map": "0.5.6",
-            "uglify-to-browserify": "1.0.2",
-            "yargs": "3.10.0"
-          }
-        },
-        "window-size": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
-          "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
-          "dev": true
-        },
-        "wordwrap": {
-          "version": "0.0.2",
-          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-          "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
-          "dev": true
-        },
-        "yargs": {
-          "version": "3.10.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-          "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
-          "dev": true,
-          "requires": {
-            "camelcase": "1.2.1",
-            "cliui": "2.1.0",
-            "decamelize": "1.2.0",
-            "window-size": "0.1.0"
-          }
-        }
-      }
     },
     "gulp": {
       "version": "3.9.1",
@@ -4810,50 +3303,6 @@
         "gulp-util": "3.0.8",
         "through2": "2.0.3",
         "vinyl-sourcemaps-apply": "0.2.1"
-      }
-    },
-    "gulp-decompress": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/gulp-decompress/-/gulp-decompress-1.2.0.tgz",
-      "integrity": "sha1-jutlpeAV+O2FMsr+KEVJYGJvDcc=",
-      "dev": true,
-      "requires": {
-        "archive-type": "3.2.0",
-        "decompress": "3.0.0",
-        "gulp-util": "3.0.8",
-        "readable-stream": "2.3.3"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-          "dev": true,
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
-        }
       }
     },
     "gulp-gzip": {
@@ -5760,66 +4209,6 @@
         "glogg": "1.0.0"
       }
     },
-    "handlebars": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-3.0.3.tgz",
-      "integrity": "sha1-DgllGi8Ps8lJFgWDcQ1VH5Lm0q0=",
-      "dev": true,
-      "requires": {
-        "optimist": "0.6.1",
-        "source-map": "0.1.43",
-        "uglify-js": "2.3.6"
-      },
-      "dependencies": {
-        "async": {
-          "version": "0.2.10",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
-          "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
-          "dev": true,
-          "optional": true
-        },
-        "source-map": {
-          "version": "0.1.43",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
-          "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
-          "dev": true,
-          "requires": {
-            "amdefine": "1.0.1"
-          }
-        },
-        "uglify-js": {
-          "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.3.6.tgz",
-          "integrity": "sha1-+gmEdwtCi3qbKoBY9GNV0U/vIRo=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "async": "0.2.10",
-            "optimist": "0.3.7",
-            "source-map": "0.1.43"
-          },
-          "dependencies": {
-            "optimist": {
-              "version": "0.3.7",
-              "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
-              "integrity": "sha1-yQlBrVnkJzMokjB00s8ufLxuwNk=",
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "wordwrap": "0.0.3"
-              }
-            }
-          }
-        },
-        "wordwrap": {
-          "version": "0.0.3",
-          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
-          "dev": true,
-          "optional": true
-        }
-      }
-    },
     "har-schema": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
@@ -5865,16 +4254,6 @@
       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
       "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
       "dev": true
-    },
-    "hasha": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/hasha/-/hasha-2.2.0.tgz",
-      "integrity": "sha1-eNfL/B5tZjA/55g3NlmEUXsvbuE=",
-      "dev": true,
-      "requires": {
-        "is-stream": "1.1.0",
-        "pinkie-promise": "2.0.1"
-      }
     },
     "hawk": {
       "version": "3.1.3",
@@ -5959,281 +4338,6 @@
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.5.tgz",
       "integrity": "sha512-JLH93mL8amZQhh/p6mfQgVBH3M6epNq3DfsXsTSuSrInVjwyYlFE1nv2AgfRCC8PoOhM0jwQ5v8s9LgbK7yGDw==",
       "dev": true
-    },
-    "imagemin": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/imagemin/-/imagemin-3.1.0.tgz",
-      "integrity": "sha1-bz8JRhLki+kTmTnb0ZaLEWdJ49U=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "concat-stream": "1.6.0",
-        "get-stdin": "3.0.2",
-        "imagemin-gifsicle": "4.2.0",
-        "imagemin-jpegtran": "4.3.2",
-        "imagemin-optipng": "4.3.0",
-        "imagemin-pngquant": "4.2.2",
-        "imagemin-svgo": "4.2.1",
-        "meow": "2.1.0",
-        "optional": "0.1.4",
-        "stream-combiner": "0.2.2",
-        "through2": "0.6.5",
-        "vinyl": "0.4.6",
-        "vinyl-fs": "0.3.14"
-      },
-      "dependencies": {
-        "camelcase": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-          "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
-          "dev": true,
-          "optional": true
-        },
-        "camelcase-keys": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
-          "integrity": "sha1-vRoRv5sxoc5JNJOpMN4aC69K1+w=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "camelcase": "1.2.1",
-            "map-obj": "1.0.1"
-          }
-        },
-        "clone": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
-          "integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8=",
-          "dev": true,
-          "optional": true
-        },
-        "get-stdin": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-3.0.2.tgz",
-          "integrity": "sha1-wc7SS5A5s43thb3xYeV3E7bdSr4=",
-          "dev": true,
-          "optional": true
-        },
-        "indent-string": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.2.tgz",
-          "integrity": "sha1-25m8xYPrarux5I3LsZmamGBBy2s=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "get-stdin": "4.0.1",
-            "minimist": "1.2.0",
-            "repeating": "1.1.3"
-          },
-          "dependencies": {
-            "get-stdin": {
-              "version": "4.0.1",
-              "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-              "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "meow": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/meow/-/meow-2.1.0.tgz",
-          "integrity": "sha1-OmP3eXfBUMFv2ESE0M72d8QYJ5k=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "camelcase-keys": "1.0.0",
-            "indent-string": "1.2.2",
-            "minimist": "1.2.0",
-            "object-assign": "2.1.1"
-          }
-        },
-        "object-assign": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
-          "integrity": "sha1-Q8NuXVaf+OSBbE76i+AtJpZ8GKo=",
-          "dev": true,
-          "optional": true
-        },
-        "readable-stream": {
-          "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
-          }
-        },
-        "repeating": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
-          "integrity": "sha1-PUEUIYh3U3SU+X93+Xhfq4EPpKw=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "is-finite": "1.0.2"
-          }
-        },
-        "stream-combiner": {
-          "version": "0.2.2",
-          "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz",
-          "integrity": "sha1-rsjLrBd7Vrb0+kec7YwZEs7lKFg=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "duplexer": "0.1.1",
-            "through": "2.3.8"
-          }
-        },
-        "through2": {
-          "version": "0.6.5",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-          "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "readable-stream": "1.0.34",
-            "xtend": "4.0.1"
-          }
-        },
-        "vinyl": {
-          "version": "0.4.6",
-          "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
-          "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "clone": "0.2.0",
-            "clone-stats": "0.0.1"
-          }
-        }
-      }
-    },
-    "imagemin-gifsicle": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/imagemin-gifsicle/-/imagemin-gifsicle-4.2.0.tgz",
-      "integrity": "sha1-D++butNHbmt2iFc2zFsLh6CHV8o=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "gifsicle": "3.0.4",
-        "is-gif": "1.0.0",
-        "through2": "0.6.5"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
-          }
-        },
-        "through2": {
-          "version": "0.6.5",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-          "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "readable-stream": "1.0.34",
-            "xtend": "4.0.1"
-          }
-        }
-      }
-    },
-    "imagemin-jpegtran": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/imagemin-jpegtran/-/imagemin-jpegtran-4.3.2.tgz",
-      "integrity": "sha1-G8bR4r0T/bZNJFUm1jWn5d/rEvw=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "is-jpg": "1.0.0",
-        "jpegtran-bin": "3.2.0",
-        "through2": "2.0.3"
-      }
-    },
-    "imagemin-optipng": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/imagemin-optipng/-/imagemin-optipng-4.3.0.tgz",
-      "integrity": "sha1-dgRmOrLuMVczJ0cm/Rw3TStErbY=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "exec-buffer": "2.0.1",
-        "is-png": "1.1.0",
-        "optipng-bin": "3.1.4",
-        "through2": "0.6.5"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
-          }
-        },
-        "through2": {
-          "version": "0.6.5",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-          "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "readable-stream": "1.0.34",
-            "xtend": "4.0.1"
-          }
-        }
-      }
-    },
-    "imagemin-pngquant": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/imagemin-pngquant/-/imagemin-pngquant-4.2.2.tgz",
-      "integrity": "sha1-LM2FPnr5+6JvKy3SUtNe6OFVxUI=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "is-png": "1.1.0",
-        "pngquant-bin": "3.1.1",
-        "through2": "2.0.3"
-      }
-    },
-    "imagemin-svgo": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/imagemin-svgo/-/imagemin-svgo-4.2.1.tgz",
-      "integrity": "sha1-VPB9xW9HJgRi32phxUvvtEtXvlU=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "is-svg": "1.1.1",
-        "svgo": "0.6.6",
-        "through2": "2.0.3"
-      }
-    },
-    "img-stats": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/img-stats/-/img-stats-0.5.2.tgz",
-      "integrity": "sha1-wgNJbELy2esuWrgjL6dWurMsnis=",
-      "dev": true,
-      "requires": {
-        "xmldom": "0.1.27"
-      }
     },
     "imurmurhash": {
       "version": "0.1.4",
@@ -6325,13 +4429,6 @@
       "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
       "dev": true
     },
-    "ip-regex": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-1.0.3.tgz",
-      "integrity": "sha1-3FiQdvZZ9BnCIgOaMzFvHHOH7/0=",
-      "dev": true,
-      "optional": true
-    },
     "is": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/is/-/is-3.2.1.tgz",
@@ -6377,12 +4474,6 @@
       "requires": {
         "builtin-modules": "1.1.1"
       }
-    },
-    "is-bzip2": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-bzip2/-/is-bzip2-1.0.0.tgz",
-      "integrity": "sha1-XuWOqlounIDiFAe+3yOuWsCRs/w=",
-      "dev": true
     },
     "is-directory": {
       "version": "0.3.1",
@@ -6435,13 +4526,6 @@
         "number-is-nan": "1.0.1"
       }
     },
-    "is-gif": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-gif/-/is-gif-1.0.0.tgz",
-      "integrity": "sha1-ptKumIkwB7/6l6HYwB1jIFgyCX4=",
-      "dev": true,
-      "optional": true
-    },
     "is-glob": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
@@ -6450,19 +4534,6 @@
       "requires": {
         "is-extglob": "1.0.0"
       }
-    },
-    "is-gzip": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-gzip/-/is-gzip-1.0.0.tgz",
-      "integrity": "sha1-bKiwe5nHeZgCWQDlVc7Y7YCHmoM=",
-      "dev": true
-    },
-    "is-jpg": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-jpg/-/is-jpg-1.0.0.tgz",
-      "integrity": "sha1-KVnBfnNDDbOCZNp1uQ3VTy2G2hw=",
-      "dev": true,
-      "optional": true
     },
     "is-my-json-valid": {
       "version": "2.16.1",
@@ -6476,12 +4547,6 @@
         "xtend": "4.0.1"
       }
     },
-    "is-natural-number": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-2.1.1.tgz",
-      "integrity": "sha1-fUxXKDd+84bD4ZSpkRv1fG3DNec=",
-      "dev": true
-    },
     "is-number": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
@@ -6490,12 +4555,6 @@
       "requires": {
         "kind-of": "3.2.2"
       }
-    },
-    "is-obj": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
-      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
-      "dev": true
     },
     "is-path-cwd": {
       "version": "1.0.0",
@@ -6538,13 +4597,6 @@
         }
       }
     },
-    "is-png": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-png/-/is-png-1.1.0.tgz",
-      "integrity": "sha1-1XSxK/J1wDUEVVcLDltXqwYgd84=",
-      "dev": true,
-      "optional": true
-    },
     "is-posix-bracket": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
@@ -6561,12 +4613,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
       "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
-      "dev": true
-    },
-    "is-redirect": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
-      "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
       "dev": true
     },
     "is-regexp": {
@@ -6593,35 +4639,10 @@
         "tryit": "1.0.3"
       }
     },
-    "is-retry-allowed": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
-      "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=",
-      "dev": true
-    },
-    "is-stream": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-      "dev": true
-    },
     "is-supported-regexp-flag": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-supported-regexp-flag/-/is-supported-regexp-flag-1.0.0.tgz",
       "integrity": "sha1-i1IMhfrnolM4LUsCZS4EVXbhO7g=",
-      "dev": true
-    },
-    "is-svg": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/is-svg/-/is-svg-1.1.1.tgz",
-      "integrity": "sha1-rA76r7ZTrFhHNwix+HNjbKEQ4xs=",
-      "dev": true,
-      "optional": true
-    },
-    "is-tar": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-tar/-/is-tar-1.0.0.tgz",
-      "integrity": "sha1-L2suF5LB9bs2UZrKqdZcDSb+hT0=",
       "dev": true
     },
     "is-typedarray": {
@@ -6639,34 +4660,16 @@
         "unc-path-regex": "0.1.2"
       }
     },
-    "is-url": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.2.tgz",
-      "integrity": "sha1-SYkFpZO/R8wtnn9zg3K792lsfyY=",
-      "dev": true
-    },
     "is-utf8": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
       "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
       "dev": true
     },
-    "is-valid-glob": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-0.3.0.tgz",
-      "integrity": "sha1-1LVcafUYhvm2XHDWwmItN+KfSP4=",
-      "dev": true
-    },
     "is-windows": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-0.2.0.tgz",
       "integrity": "sha1-3hqm1j6indJIc3tp8f+LgALSEIw=",
-      "dev": true
-    },
-    "is-zip": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-zip/-/is-zip-1.0.0.tgz",
-      "integrity": "sha1-R7Co/004p2QxzP2ZqOFaTIa6IyU=",
       "dev": true
     },
     "isarray": {
@@ -6703,18 +4706,6 @@
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
       "dev": true
-    },
-    "jpegtran-bin": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/jpegtran-bin/-/jpegtran-bin-3.2.0.tgz",
-      "integrity": "sha1-9g7PSumZwL2tLp+83ytvCYHnops=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "bin-build": "2.2.0",
-        "bin-wrapper": "3.0.2",
-        "logalot": "2.1.0"
-      }
     },
     "js-base64": {
       "version": "2.1.9",
@@ -6830,12 +4821,6 @@
         }
       }
     },
-    "kew": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/kew/-/kew-0.7.0.tgz",
-      "integrity": "sha1-edk9LTM2PW/dKXCzNdkUGtWR15s=",
-      "dev": true
-    },
     "keypress": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/keypress/-/keypress-0.1.0.tgz",
@@ -6875,65 +4860,11 @@
       "integrity": "sha512-QMQcnKAiQccfQTqtBh/qwquGZ2XK/DXND1jrcN9M8gMMy99Gwla7GQjndVUsEqIaRyP6bsFRuhwRj5poafBGJQ==",
       "dev": true
     },
-    "lazy-cache": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
-      "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
-      "dev": true
-    },
     "lazy-debug-legacy": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/lazy-debug-legacy/-/lazy-debug-legacy-0.0.1.tgz",
       "integrity": "sha1-U3cWwHduTPeePtG2IfdljCkRsbE=",
       "dev": true
-    },
-    "lazy-req": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/lazy-req/-/lazy-req-1.1.0.tgz",
-      "integrity": "sha1-va6+rTD42CQDnODOFJ1Nqge6H6w=",
-      "dev": true,
-      "optional": true
-    },
-    "lazystream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
-      "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
-      "dev": true,
-      "requires": {
-        "readable-stream": "2.3.3"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-          "dev": true,
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
-        }
-      }
     },
     "lcid": {
       "version": "1.0.0",
@@ -7279,12 +5210,6 @@
       "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
       "dev": true
     },
-    "lodash.isequal": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
-      "dev": true
-    },
     "lodash.isfunction": {
       "version": "3.0.8",
       "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-3.0.8.tgz",
@@ -7442,23 +5367,6 @@
         }
       }
     },
-    "logalot": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/logalot/-/logalot-2.1.0.tgz",
-      "integrity": "sha1-X46MkNME7fElMJUaVVSruMXj9VI=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "figures": "1.7.0",
-        "squeak": "1.3.0"
-      }
-    },
-    "longest": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "dev": true
-    },
     "loud-rejection": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
@@ -7467,25 +5375,6 @@
       "requires": {
         "currently-unhandled": "0.4.1",
         "signal-exit": "3.0.2"
-      }
-    },
-    "lowercase-keys": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
-      "integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY=",
-      "dev": true
-    },
-    "lpad-align": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/lpad-align/-/lpad-align-1.1.2.tgz",
-      "integrity": "sha1-IfYArBwwlcPG5JfuZyce4ISB/p4=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "get-stdin": "4.0.1",
-        "indent-string": "2.1.0",
-        "longest": "1.0.1",
-        "meow": "3.7.0"
       }
     },
     "lru-cache": {
@@ -7588,64 +5477,6 @@
       "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz",
       "integrity": "sha1-dTHjnUlJwoGma4xabgJl6LBYlNo=",
       "dev": true
-    },
-    "merge-defaults": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/merge-defaults/-/merge-defaults-0.2.1.tgz",
-      "integrity": "sha1-3UIkjrlrtqUVIXJDIccv+Vg93oA=",
-      "dev": true,
-      "requires": {
-        "lodash": "2.4.2"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
-          "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
-          "dev": true
-        }
-      }
-    },
-    "merge-stream": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
-      "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
-      "dev": true,
-      "requires": {
-        "readable-stream": "2.3.3"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-          "dev": true,
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
-        }
-      }
     },
     "micromatch": {
       "version": "2.3.11",
@@ -7861,12 +5692,6 @@
       "integrity": "sha1-6f+EFBimsux6SV6TmYT3jxY+bjE=",
       "dev": true
     },
-    "ncp": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/ncp/-/ncp-0.4.2.tgz",
-      "integrity": "sha1-q8xsvT7C7Spyn/bnwfqPAXhKhXQ=",
-      "dev": true
-    },
     "nightmare": {
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/nightmare/-/nightmare-2.10.0.tgz",
@@ -8066,12 +5891,6 @@
         }
       }
     },
-    "node-status-codes": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-status-codes/-/node-status-codes-1.0.0.tgz",
-      "integrity": "sha1-WuVUHQJGRdMqWPzdyc7s6nrjrC8=",
-      "dev": true
-    },
     "node.extend": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/node.extend/-/node.extend-1.1.6.tgz",
@@ -8252,37 +6071,6 @@
       "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
       "dev": true
     },
-    "optimist": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-      "dev": true,
-      "requires": {
-        "minimist": "0.0.10",
-        "wordwrap": "0.0.3"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "0.0.10",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-          "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
-          "dev": true
-        },
-        "wordwrap": {
-          "version": "0.0.3",
-          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
-          "dev": true
-        }
-      }
-    },
-    "optional": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/optional/-/optional-0.1.4.tgz",
-      "integrity": "sha512-gtvrrCfkE08wKcgXaVwQVgwEQ8vel2dc5DDBn9RLQZ3YtmtkBss6A2HY6BnJH4N/4Ku97Ri/SF8sNWE2225WJw==",
-      "dev": true,
-      "optional": true
-    },
     "optionator": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
@@ -8295,18 +6083,6 @@
         "prelude-ls": "1.1.2",
         "type-check": "0.3.2",
         "wordwrap": "1.0.0"
-      }
-    },
-    "optipng-bin": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/optipng-bin/-/optipng-bin-3.1.4.tgz",
-      "integrity": "sha1-ldNPLEiHBPb9cGBr/qDGWfHZXYQ=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "bin-build": "2.2.0",
-        "bin-wrapper": "3.0.2",
-        "logalot": "2.1.0"
       }
     },
     "orchestrator": {
@@ -8325,13 +6101,6 @@
       "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.1.0.tgz",
       "integrity": "sha1-/VZamvjrRHO6abbtijQ1LLVS8SY=",
       "dev": true
-    },
-    "os-filter-obj": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/os-filter-obj/-/os-filter-obj-1.0.3.tgz",
-      "integrity": "sha1-WRUzDZDs7VV9LZOKMcbdIU2cY60=",
-      "dev": true,
-      "optional": true
     },
     "os-homedir": {
       "version": "1.0.2",
@@ -8502,57 +6271,6 @@
       "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
       "dev": true
     },
-    "phantomjs-prebuilt": {
-      "version": "2.1.15",
-      "resolved": "https://registry.npmjs.org/phantomjs-prebuilt/-/phantomjs-prebuilt-2.1.15.tgz",
-      "integrity": "sha1-IPhugtM0nFBZF1J3RbekEeCLOQM=",
-      "dev": true,
-      "requires": {
-        "es6-promise": "4.0.5",
-        "extract-zip": "1.6.5",
-        "fs-extra": "1.0.0",
-        "hasha": "2.2.0",
-        "kew": "0.7.0",
-        "progress": "1.1.8",
-        "request": "2.81.0",
-        "request-progress": "2.0.1",
-        "which": "1.2.14"
-      },
-      "dependencies": {
-        "es6-promise": {
-          "version": "4.0.5",
-          "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.0.5.tgz",
-          "integrity": "sha1-eILzCt3lskDM+n99eMVIMwlRrkI=",
-          "dev": true
-        },
-        "fs-extra": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-1.0.0.tgz",
-          "integrity": "sha1-zTzl9+fLYUWIP8rjGR6Yd/hYeVA=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "jsonfile": "2.4.0",
-            "klaw": "1.3.1"
-          }
-        },
-        "graceful-fs": {
-          "version": "4.1.11",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-          "dev": true
-        },
-        "jsonfile": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
-          "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11"
-          }
-        }
-      }
-    },
     "pify": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
@@ -8629,18 +6347,6 @@
       "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz",
       "integrity": "sha1-0aIUg/0iu0HlihL6NCGCMUCJfEU=",
       "dev": true
-    },
-    "pngquant-bin": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/pngquant-bin/-/pngquant-bin-3.1.1.tgz",
-      "integrity": "sha1-0STZinWpSH9AwWQLTb/Lsr1aH9E=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "bin-build": "2.2.0",
-        "bin-wrapper": "3.0.2",
-        "logalot": "2.1.0"
-      }
     },
     "postcss": {
       "version": "6.0.11",
@@ -8843,12 +6549,6 @@
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true
     },
-    "prepend-http": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
-      "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
-      "dev": true
-    },
     "preserve": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
@@ -8913,12 +6613,6 @@
           }
         }
       }
-    },
-    "prr": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz",
-      "integrity": "sha1-GoS4WQgyVQFBGFPQCB7j+obikmo=",
-      "dev": true
     },
     "pseudomap": {
       "version": "1.0.2",
@@ -9021,48 +6715,6 @@
           "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
           "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
           "dev": true
-        }
-      }
-    },
-    "read-all-stream": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-3.1.0.tgz",
-      "integrity": "sha1-NcPhd/IHjveJ7kv6+kNzB06u9Po=",
-      "dev": true,
-      "requires": {
-        "pinkie-promise": "2.0.1",
-        "readable-stream": "2.3.3"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-          "dev": true,
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
         }
       }
     },
@@ -9320,23 +6972,6 @@
         }
       }
     },
-    "request-progress": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-2.0.1.tgz",
-      "integrity": "sha1-XTa7V5YcZzqlt4jbyBQf3yO0Tgg=",
-      "dev": true,
-      "requires": {
-        "throttleit": "1.0.0"
-      },
-      "dependencies": {
-        "throttleit": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-1.0.0.tgz",
-          "integrity": "sha1-nnhYNtr0Z0MUWlmEtiaNgoUorGw=",
-          "dev": true
-        }
-      }
-    },
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -9406,15 +7041,6 @@
         "onetime": "1.1.0"
       }
     },
-    "right-align": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-      "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
-      "dev": true,
-      "requires": {
-        "align-text": "0.1.4"
-      }
-    },
     "rimraf": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
@@ -9448,12 +7074,6 @@
           }
         }
       }
-    },
-    "rsvp": {
-      "version": "3.0.15",
-      "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.0.15.tgz",
-      "integrity": "sha1-JiT4ZEmicvF6Jj/09iF+ENrYsDk=",
-      "dev": true
     },
     "run-async": {
       "version": "0.1.0",
@@ -9616,57 +7236,11 @@
         }
       }
     },
-    "seek-bzip": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.5.tgz",
-      "integrity": "sha1-z+kXyz0nS8/6x5J1ivUxc+sfq9w=",
-      "dev": true,
-      "requires": {
-        "commander": "2.8.1"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "2.8.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
-          "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
-          "dev": true,
-          "requires": {
-            "graceful-readlink": "1.0.1"
-          }
-        }
-      }
-    },
     "semver": {
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
       "integrity": "sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto=",
       "dev": true
-    },
-    "semver-regex": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-1.0.0.tgz",
-      "integrity": "sha1-kqSWkGX5xwxpR1PVUkj8aPj2Usk=",
-      "dev": true,
-      "optional": true
-    },
-    "semver-truncate": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/semver-truncate/-/semver-truncate-1.1.2.tgz",
-      "integrity": "sha1-V/Qd5pcHpicJp+AQS6IRcQnqR+g=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "semver": "5.4.1"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.4.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-          "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
-          "dev": true,
-          "optional": true
-        }
-      }
     },
     "sequencify": {
       "version": "0.0.7",
@@ -9833,18 +7407,6 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
-    "squeak": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/squeak/-/squeak-1.3.0.tgz",
-      "integrity": "sha1-MwRQN7ZDiLVnZ0uEMiplIQc5FsM=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "chalk": "1.1.3",
-        "console-stream": "0.1.1",
-        "lpad-align": "1.1.2"
-      }
-    },
     "sshpk": {
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
@@ -9869,12 +7431,6 @@
         }
       }
     },
-    "stat-mode": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/stat-mode/-/stat-mode-0.2.2.tgz",
-      "integrity": "sha1-5sgLYjEj19gM8TLOU480YokHJQI=",
-      "dev": true
-    },
     "statuses": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
@@ -9890,67 +7446,10 @@
         "duplexer": "0.1.1"
       }
     },
-    "stream-combiner2": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.1.1.tgz",
-      "integrity": "sha1-+02KFCDqNidk4hrUeAOXvry0HL4=",
-      "dev": true,
-      "requires": {
-        "duplexer2": "0.1.4",
-        "readable-stream": "2.3.3"
-      },
-      "dependencies": {
-        "duplexer2": {
-          "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
-          "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
-          "dev": true,
-          "requires": {
-            "readable-stream": "2.3.3"
-          }
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-          "dev": true,
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
-        }
-      }
-    },
     "stream-consume": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/stream-consume/-/stream-consume-0.1.0.tgz",
       "integrity": "sha1-pB6tGm1ggc63n2WwYZAbbY89HQ8=",
-      "dev": true
-    },
-    "stream-shift": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
-      "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
       "dev": true
     },
     "stream-to-array": {
@@ -10067,37 +7566,6 @@
         }
       }
     },
-    "strip-dirs": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-1.1.1.tgz",
-      "integrity": "sha1-lgu9EoeETzl1pFWKoQOoJV4kVqA=",
-      "dev": true,
-      "requires": {
-        "chalk": "1.1.3",
-        "get-stdin": "4.0.1",
-        "is-absolute": "0.1.7",
-        "is-natural-number": "2.1.1",
-        "minimist": "1.2.0",
-        "sum-up": "1.0.3"
-      },
-      "dependencies": {
-        "is-absolute": {
-          "version": "0.1.7",
-          "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
-          "integrity": "sha1-hHSREZ/MtftDYhfMc39/qtUPYD8=",
-          "dev": true,
-          "requires": {
-            "is-relative": "0.1.3"
-          }
-        },
-        "is-relative": {
-          "version": "0.1.3",
-          "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz",
-          "integrity": "sha1-kF/uiuhvRbPsYUvDwVyGnfCHboI=",
-          "dev": true
-        }
-      }
-    },
     "strip-indent": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
@@ -10112,15 +7580,6 @@
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
       "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=",
       "dev": true
-    },
-    "strip-outer": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/strip-outer/-/strip-outer-1.0.0.tgz",
-      "integrity": "sha1-qsC6YNLpDF1PJ1/Yhp/ZotMQ/7g=",
-      "dev": true,
-      "requires": {
-        "escape-string-regexp": "1.0.5"
-      }
     },
     "style-search": {
       "version": "0.1.0",
@@ -10412,15 +7871,6 @@
         "postcss": "6.0.11"
       }
     },
-    "sum-up": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sum-up/-/sum-up-1.0.3.tgz",
-      "integrity": "sha1-HGYfZnBX9jvLeHWqFDi8FiUlFW4=",
-      "dev": true,
-      "requires": {
-        "chalk": "1.1.3"
-      }
-    },
     "sumchecker": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/sumchecker/-/sumchecker-1.3.1.tgz",
@@ -10442,59 +7892,6 @@
       "resolved": "https://registry.npmjs.org/svg-tags/-/svg-tags-1.0.0.tgz",
       "integrity": "sha1-WPcc7jvVGbWdSyqEO2x95krAR2Q=",
       "dev": true
-    },
-    "svg-to-png": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/svg-to-png/-/svg-to-png-3.1.2.tgz",
-      "integrity": "sha1-G9IjIf+VF3jHMU9dIIvrDTFgVAE=",
-      "dev": true,
-      "requires": {
-        "imagemin": "3.1.0",
-        "phantomjs-prebuilt": "2.1.15"
-      }
-    },
-    "svgo": {
-      "version": "0.6.6",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-0.6.6.tgz",
-      "integrity": "sha1-s0CIkDbyD5tEdUMHfQ9Vc+0ETAg=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "coa": "1.0.4",
-        "colors": "1.1.2",
-        "csso": "2.0.0",
-        "js-yaml": "3.6.1",
-        "mkdirp": "0.5.1",
-        "sax": "1.2.4",
-        "whet.extend": "0.9.9"
-      },
-      "dependencies": {
-        "colors": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
-          "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
-          "dev": true,
-          "optional": true
-        },
-        "esprima": {
-          "version": "2.7.3",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
-          "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
-          "dev": true,
-          "optional": true
-        },
-        "js-yaml": {
-          "version": "3.6.1",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.1.tgz",
-          "integrity": "sha1-bl/mfYsgXOTSL60Ft3geja3MSzA=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "argparse": "1.0.9",
-            "esprima": "2.7.3"
-          }
-        }
-      }
     },
     "table": {
       "version": "3.8.3",
@@ -10558,86 +7955,6 @@
         "block-stream": "0.0.9",
         "fstream": "1.0.11",
         "inherits": "2.0.3"
-      }
-    },
-    "tar-stream": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.4.tgz",
-      "integrity": "sha1-NlSc8E7RrumyowwBQyUiONr5QBY=",
-      "dev": true,
-      "requires": {
-        "bl": "1.2.1",
-        "end-of-stream": "1.4.0",
-        "readable-stream": "2.3.3",
-        "xtend": "4.0.1"
-      },
-      "dependencies": {
-        "end-of-stream": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
-          "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
-          "dev": true,
-          "requires": {
-            "once": "1.4.0"
-          }
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true
-        },
-        "once": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-          "dev": true,
-          "requires": {
-            "wrappy": "1.0.2"
-          }
-        },
-        "readable-stream": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-          "dev": true,
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
-        }
-      }
-    },
-    "tempfile": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/tempfile/-/tempfile-1.1.1.tgz",
-      "integrity": "sha1-W8xOrsxKsscH2LwR2ZzMmiyyh/I=",
-      "dev": true,
-      "requires": {
-        "os-tmpdir": "1.0.2",
-        "uuid": "2.0.3"
-      },
-      "dependencies": {
-        "uuid": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
-          "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho=",
-          "dev": true
-        }
       }
     },
     "text-table": {
@@ -10718,16 +8035,6 @@
         }
       }
     },
-    "through2-filter": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/through2-filter/-/through2-filter-2.0.0.tgz",
-      "integrity": "sha1-YLxVoNrLdghdsfna6Zq0P4PWIuw=",
-      "dev": true,
-      "requires": {
-        "through2": "2.0.3",
-        "xtend": "4.0.1"
-      }
-    },
     "tildify": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/tildify/-/tildify-1.2.0.tgz",
@@ -10743,21 +8050,6 @@
       "integrity": "sha1-dkpaEa9QVhkhsTPztE5hhofg9cM=",
       "dev": true
     },
-    "timed-out": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-3.1.3.tgz",
-      "integrity": "sha1-lYYL/MXHbCd/j4Mm/Q9bLiDrohc=",
-      "dev": true
-    },
-    "to-absolute-glob": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-0.1.1.tgz",
-      "integrity": "sha1-HN+kcqnvUMI57maZm2YsoOs5k38=",
-      "dev": true,
-      "requires": {
-        "extend-shallow": "2.0.1"
-      }
-    },
     "tough-cookie": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
@@ -10772,15 +8064,6 @@
       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
       "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
       "dev": true
-    },
-    "trim-repeated": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz",
-      "integrity": "sha1-42RqLqTokTEr9+rObPsFOAvAHCE=",
-      "dev": true,
-      "requires": {
-        "escape-string-regexp": "1.0.5"
-      }
     },
     "tryit": {
       "version": "1.0.3",
@@ -10839,13 +8122,6 @@
         "source-map": "0.5.6"
       }
     },
-    "uglify-to-browserify": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
-      "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
-      "dev": true,
-      "optional": true
-    },
     "unc-path-regex": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
@@ -10876,36 +8152,11 @@
       "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
       "dev": true
     },
-    "unzip-response": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-1.0.2.tgz",
-      "integrity": "sha1-uYTwh3/AqJwsdzzB73tbIytbBv4=",
-      "dev": true
-    },
     "urix": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
       "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
       "dev": true
-    },
-    "url-parse-lax": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
-      "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
-      "dev": true,
-      "requires": {
-        "prepend-http": "1.0.4"
-      }
-    },
-    "url-regex": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/url-regex/-/url-regex-3.2.0.tgz",
-      "integrity": "sha1-260eDJ4p4QXdCx8J9oYvf9tIJyQ=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "ip-regex": "1.0.3"
-      }
     },
     "user-home": {
       "version": "1.1.1",
@@ -10951,12 +8202,6 @@
         "user-home": "1.1.1"
       }
     },
-    "vali-date": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/vali-date/-/vali-date-1.0.0.tgz",
-      "integrity": "sha1-G5BKWWCfsyjvB4E4Qgk09rhnCaY=",
-      "dev": true
-    },
     "validate-npm-package-license": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
@@ -10985,54 +8230,6 @@
         "clone": "1.0.2",
         "clone-stats": "0.0.1",
         "replace-ext": "0.0.1"
-      }
-    },
-    "vinyl-assign": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/vinyl-assign/-/vinyl-assign-1.2.1.tgz",
-      "integrity": "sha1-TRmIkbVRWRHXcajNnFSApGoHSkU=",
-      "dev": true,
-      "requires": {
-        "object-assign": "4.1.1",
-        "readable-stream": "2.3.3"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-          "dev": true,
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
-        }
       }
     },
     "vinyl-file": {
@@ -11142,15 +8339,6 @@
         "source-map": "0.5.6"
       }
     },
-    "ware": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/ware/-/ware-1.3.0.tgz",
-      "integrity": "sha1-0bFPOdLiy0q4xAmPdW/ksWTkc9Q=",
-      "dev": true,
-      "requires": {
-        "wrap-fn": "0.1.5"
-      }
-    },
     "wcwidth": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
@@ -11227,23 +8415,6 @@
         "strip-ansi": "3.0.1"
       }
     },
-    "wrap-fn": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/wrap-fn/-/wrap-fn-0.1.5.tgz",
-      "integrity": "sha1-8htuQQFv9KfjFyDbxjoJAWvfmEU=",
-      "dev": true,
-      "requires": {
-        "co": "3.1.0"
-      },
-      "dependencies": {
-        "co": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/co/-/co-3.1.0.tgz",
-          "integrity": "sha1-TqVOpaCJOBUxheFSEMaNkJK8G3g=",
-          "dev": true
-        }
-      }
-    },
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -11258,12 +8429,6 @@
       "requires": {
         "mkdirp": "0.5.1"
       }
-    },
-    "xmldom": {
-      "version": "0.1.27",
-      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.27.tgz",
-      "integrity": "sha1-1QH5ezvbQDr4757MIFcxh6rawOk=",
-      "dev": true
     },
     "xtend": {
       "version": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
   "devDependencies": {
     "del": "^3.0.0",
     "glob": "^7.1.2",
-    "grunticon-lib": "^1.2.3",
     "gulp": "^3.9.1",
     "gulp-autoprefixer": "^4.0.0",
     "gulp-bless": "^4.0.0",


### PR DESCRIPTION
<img width="1000" alt="screen shot 2017-11-17 at 12 51 40" src="https://user-images.githubusercontent.com/7100966/33007264-9f3594fe-cdd6-11e7-931f-e77ceeb91a21.png">

`grunticon-lib` depends on a vulnerable version of handlebars and does not have any further upgrades with a  fix.

[Link to issue](https://github.com/filamentgroup/grunticon-lib/issues/30)