### PR TITLE
Run flake8 on molo directory with Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,8 +30,6 @@ matrix:
       after_success: []
   allow_failures:
     - python: '3.6'
-      env: TEST=molo_lint
-    - python: '3.6'
       env: TEST=build
 
 services:

--- a/molo/core/tasks.py
+++ b/molo/core/tasks.py
@@ -344,7 +344,7 @@ def copy_sections_index(
             'source': section_index.get_parent().title,
             'to': to.title
         })
-    except Exception, e:
+    except Exception as e:
         logging.error(e, exc_info=True)
         send_copy_failed_email(user.email, {
             'name': (user.get_full_name() or user.username) if user else None,
@@ -456,7 +456,7 @@ def import_site(root_url, site_pk, user_pk):
                 'logs': logger.get_email_logs()
             },
             csv=csvfile)
-    except Exception, e:
+    except Exception as e:
         logging.error(e, exc_info=True)
         send_copy_failed_email(user.email, {
             'name': (user.get_full_name() or user.username) if user else None,


### PR DESCRIPTION
There are only these 2 tiny exceptions left which prevent flake8 from passing successfully on Python 3, so let's do it.