### PR TITLE
Pin django-phonenumber-field to 1.3.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ install_requires = [
     'django-libsass',
     'django-mptt==0.8.6',
     'djangorestframework==3.4.0',
-    'django-phonenumber-field',
+    'django-phonenumber-field==1.3.0',
     'django-import-export',
     'django-daterange-filter',
     'elastic-git',


### PR DESCRIPTION
Version 2 was released about one day ago which drops support for the version of Django that we're using. We need to pin the version to ensure we don't get a conflict.