### PR TITLE
Re-add draft title dependency to migration 33

### DIFF
--- a/molo/core/migrations/0033_bannerindexpage_footerindexpage_sectionindexpage.py
+++ b/molo/core/migrations/0033_bannerindexpage_footerindexpage_sectionindexpage.py
@@ -9,6 +9,7 @@ class Migration(migrations.Migration):
 
     dependencies = [
         ('wagtailcore', '0028_merge'),
+        ('wagtailcore', '0040_page_draft_title'),
         ('core', '0032_sitesettings_ga_tag_manager'),
     ]
 


### PR DESCRIPTION
This dependency was removed in 8a2decc343b7fb5278b1d1f728b48caf28c2d473 but I don't think it should have been. The removal causes new databases to fail to run migrations correctly.

Depends on #506 to fix the build first.