### PR TITLE
Use Wagtail hook to delete page translation

### DIFF
--- a/molo/core/models.py
+++ b/molo/core/models.py
@@ -11,8 +11,7 @@ from django.db import models
 from django.utils.translation import ugettext_lazy as _
 from django.utils.translation import get_language_from_request
 from django.shortcuts import redirect
-from django.db.models.signals import (
-    pre_delete, post_delete, pre_save, post_save)
+from django.db.models.signals import (pre_save, post_save)
 from django.dispatch import receiver, Signal
 from django.template.response import TemplateResponse
 
@@ -1734,27 +1733,3 @@ FooterPage.promote_panels = [
     MultiFieldPanel(
         Page.promote_panels,
         "Common page configuration", "collapsible collapsed")]
-
-
-pages_to_delete = []
-
-
-@receiver(pre_delete, sender=Page)
-def on_page_delete(sender, instance, *a, **kw):
-    ids = PageTranslation.objects.filter(
-        page=instance).values_list('translated_page__id')
-    pages_to_delete.extend(Page.objects.filter(id__in=ids))
-
-
-@receiver(post_delete, sender=Page)
-def on_post_page_delete(sender, instance, *a, **kw):
-    # When we try to delete a translated page in our pre_delete, wagtail
-    # pre_delete function would want to get the same page too, but since we
-    # have already deleted it, wagtail would not be able to find it, therefore
-    # we have to get the translated page in our pre_delete and use a global
-    # variable to store it and pass it into the post_delete and remove it here
-    for p in pages_to_delete:
-        p.delete()
-
-    global pages_to_delete
-    del pages_to_delete[:]

--- a/molo/core/tests/test_models.py
+++ b/molo/core/tests/test_models.py
@@ -12,7 +12,7 @@ from django.core.exceptions import ValidationError
 from mock import patch
 
 from molo.core.models import (
-    ArticlePage, CmsSettings, PageTranslation, SectionPage, Main,
+    ArticlePage, CmsSettings, Main,
     SiteLanguageRelation, Languages, SectionIndexPage, FooterIndexPage,
     BannerIndexPage, TagIndexPage, BannerPage, ReactionQuestionIndexPage,
     Timezone,
@@ -504,89 +504,6 @@ class TestModels(TestCase, MoloTestCaseMixin):
         self.assertContains(response, 'English')
         self.assertContains(response, 'français')
         self.assertNotContains(response, 'español')
-
-    def test_signal_on_page_delete_removes_translations(self):
-        spanish = SiteLanguageRelation.objects.create(
-            language_setting=self.language_setting,
-            locale='es',
-            is_active=True)
-
-        section = self.mk_section(
-            self.section_index, title="Section", slug="section")
-        self.mk_section_translation(section, self.french)
-        self.mk_section_translation(section, spanish)
-
-        section_sub1 = self.mk_section(
-            section, title='Section subsection')
-        self.mk_section_translation(section_sub1, self.french)
-        p1, p2 = self.mk_articles(section_sub1, 2)
-        self.mk_article_translation(p1, self.french)
-        self.mk_article_translation(p1, spanish)
-
-        section_sub2 = self.mk_section(
-            section, title='Section subsection')
-        p3, p4 = self.mk_articles(section_sub2, 2)
-        self.mk_article_translation(p4, self.french)
-
-        p5, p6 = self.mk_articles(section, 2)
-        self.mk_article_translation(p5, self.french)
-
-        self.mk_section_translation(self.yourmind, self.french)
-        self.mk_section_translation(self.yourmind_sub, self.french)
-
-        p7, p8, p9 = self.mk_articles(self.yourmind_sub, 3)
-        self.mk_article_translation(p7, self.french)
-        self.mk_article_translation(p7, spanish)
-        self.mk_article_translation(p8, self.french)
-        sub_sec = self.mk_section(self.yourmind_sub, title='Sub sec')
-
-        self.assertEqual(ArticlePage.objects.descendant_of(
-            self.main).count(), 16)
-        self.assertEqual(SectionPage.objects.descendant_of(
-            self.main).count(), 11)
-        self.assertEqual(PageTranslation.objects.all().count(), 12)
-
-        section.delete()
-        self.assertEqual(ArticlePage.objects.descendant_of(
-            self.main).count(), 6)
-        self.assertEqual(SectionPage.objects.descendant_of(
-            self.main).count(), 5)
-        self.assertEqual(PageTranslation.objects.all().count(), 5)
-
-        p7.delete()
-        self.assertEqual(ArticlePage.objects.descendant_of(
-            self.main).count(), 3)
-        self.assertEqual(SectionPage.objects.descendant_of(
-            self.main).count(), 5)
-        self.assertEqual(PageTranslation.objects.all().count(), 3)
-
-        p9.delete()
-        self.assertEqual(ArticlePage.objects.descendant_of(
-            self.main).count(), 2)
-        self.assertEqual(SectionPage.objects.descendant_of(
-            self.main).count(), 5)
-        self.assertEqual(PageTranslation.objects.all().count(), 3)
-
-        sub_sec.delete()
-        self.assertEqual(ArticlePage.objects.descendant_of(
-            self.main).count(), 2)
-        self.assertEqual(SectionPage.objects.descendant_of(
-            self.main).count(), 4)
-        self.assertEqual(PageTranslation.objects.all().count(), 3)
-
-        self.yourmind_sub.delete()
-        self.assertEqual(ArticlePage.objects.descendant_of(
-            self.main).count(), 0)
-        self.assertEqual(SectionPage.objects.descendant_of(
-            self.main).count(), 2)
-        self.assertEqual(PageTranslation.objects.all().count(), 1)
-
-        self.yourmind.delete()
-        self.assertEqual(ArticlePage.objects.descendant_of(
-            self.main).count(), 0)
-        self.assertEqual(SectionPage.objects.descendant_of(
-            self.main).count(), 0)
-        self.assertEqual(PageTranslation.objects.all().count(), 0)
 
     def test_get_translation_template_tag(self):
         section = self.mk_section(self.section_index)

--- a/molo/core/tests/wagtail_hooks/test_delete_page_translations.py
+++ b/molo/core/tests/wagtail_hooks/test_delete_page_translations.py
@@ -1,0 +1,70 @@
+from django.test import TestCase
+
+from molo.core.models import (
+    ArticlePage,
+    Languages,
+    PageTranslation,
+    SiteLanguageRelation,
+)
+from molo.core.tests.base import MoloTestCaseMixin
+
+
+class TestHookDeletePageTranslations(TestCase, MoloTestCaseMixin):
+    def setUp(self):
+        self.mk_main()
+
+        language_setting = Languages.for_site(self.main.get_site())
+
+        SiteLanguageRelation.objects.create(
+            language_setting=language_setting,
+            locale='en',
+        )
+
+        zulu = SiteLanguageRelation.objects.create(
+            language_setting=language_setting,
+            locale='zu',
+        )
+
+        xhosa = SiteLanguageRelation.objects.create(
+            language_setting=language_setting,
+            locale='xh',
+        )
+
+        self.login()
+
+        self.page_english = self.mk_article(self.main, title='En')
+
+        self.page_xhosa = self.mk_article_translation(
+            self.page_english, xhosa, title='Xh')
+        self.page_zulu = self.mk_article_translation(
+            self.page_english, zulu, title='Zu')
+
+    def test_does_not_delete_on_get_request(self):
+        response = self.client.get(
+            '/admin/pages/{0}/delete/'.format(self.page_english.id))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(ArticlePage.objects.filter(title='En').count(), 1)
+        self.assertEqual(ArticlePage.objects.filter(title='Xh').count(), 1)
+        self.assertEqual(ArticlePage.objects.filter(title='Zu').count(), 1)
+        self.assertEqual(PageTranslation.objects.all().count(), 2)
+
+    def test_deletes_all_on_post_request(self):
+        response = self.client.post(
+            '/admin/pages/{0}/delete/'.format(self.page_english.id))
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(ArticlePage.objects.filter(title='En').count(), 0)
+        self.assertEqual(ArticlePage.objects.filter(title='Xh').count(), 0)
+        self.assertEqual(ArticlePage.objects.filter(title='Zu').count(), 0)
+        self.assertEqual(PageTranslation.objects.all().count(), 0)
+
+    def test_delete_translation_does_not_delete_original(self):
+        response = self.client.post(
+            '/admin/pages/{0}/delete/'.format(self.page_zulu.id))
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(ArticlePage.objects.filter(title='En').count(), 1)
+        self.assertEqual(ArticlePage.objects.filter(title='Xh').count(), 1)
+        self.assertEqual(ArticlePage.objects.filter(title='Zu').count(), 0)
+        self.assertEqual(PageTranslation.objects.all().count(), 1)

--- a/molo/core/wagtail_hooks.py
+++ b/molo/core/wagtail_hooks.py
@@ -6,7 +6,7 @@ from molo.core.admin import (
 )
 from molo.core.admin_views import ReactionQuestionResultsAdminView, \
     ReactionQuestionSummaryAdminView
-from molo.core.models import Languages
+from molo.core.models import Languages, PageTranslation
 from molo.core.utils import create_new_article_relations
 
 
@@ -81,6 +81,16 @@ def add_new_tag_article_relations(request, page, new_page):
 @hooks.register('after_copy_page')
 def copy_translation_pages_hook(request, page, new_page):
     copy_translation_pages(page, new_page)
+
+
+@hooks.register('before_delete_page')
+def delete_page_translations(request, page):
+    if request.method == 'POST':
+        ids = PageTranslation.objects.filter(
+            page=page).values_list('translated_page__id')
+
+        for page in Page.objects.filter(id__in=ids):
+            page.delete()
 
 
 # API admin


### PR DESCRIPTION
Previously we used Django receivers to delete page translations whenever a page was deleted, but this is complex and relies on a global variable `pages_to_delete`.

It's much better to use a Wagtail hook for this. Unfortuantely there's still a bit of complexity here. The before_delete_page hook runs for all requests (GET and POST, on the delete confirmation page). The after_delete_page runs after the page has been deleted, so we can't fetch the translations.

I think the best solution is to run this in the before hook but to duplicate the logic to test if the request is a POST. It's not perfect but it's nicer than the Django signals.