### PR TITLE
Remove UNICORE_DISTRIBUTE_API from test settings

### DIFF
--- a/local_test_settings.py
+++ b/local_test_settings.py
@@ -22,7 +22,6 @@ LOGIN_URL = '/accounts/login/'
 CAS_VERSION = '3'
 
 
-UNICORE_DISTRIBUTE_API = 'http://testserver:6543'
 CELERY_ALWAYS_EAGER = True
 
 DEAFULT_SITE_PORT = 8000


### PR DESCRIPTION
This stopped being used in 11457e0fa578f09e7e8a4fd0f1595b4e47ab109c