### PR TITLE
Add ProfilePasswordChangeForm to view profile view

### DIFF
--- a/molo/profiles/tests/test_views.py
+++ b/molo/profiles/tests/test_views.py
@@ -1107,6 +1107,11 @@ class MyProfileViewTest(TestCase, MoloTestCaseMixin):
         self.assertContains(response, 'tester')
         self.assertContains(response, 'The Alias')
 
+        self.assertTrue(isinstance(
+            response.context['password_change_form'],
+            ProfilePasswordChangeForm,
+        ))
+
 
 @override_settings(
     ROOT_URLCONF='molo.profiles.tests.test_views', LOGIN_URL='/login/')

--- a/molo/profiles/views.py
+++ b/molo/profiles/views.py
@@ -127,6 +127,11 @@ class MyProfileView(TemplateView):
     """
     template_name = 'profiles/viewprofile.html'
 
+    def get_context_data(self, **kwargs):
+        context = super(MyProfileView, self).get_context_data(**kwargs)
+        context['password_change_form'] = forms.ProfilePasswordChangeForm()
+        return context
+
 
 class MyProfileEdit(UpdateView):
     """


### PR DESCRIPTION
This is used by molo-gem which sets it using a context processor on every single request. Instead, it's better to provide it in the view here and not process the form on every single request.