### PR TITLE
Remove localisation of security questions in form

### DIFF
--- a/molo/profiles/forms.py
+++ b/molo/profiles/forms.py
@@ -7,7 +7,6 @@ from django.forms.extras.widgets import SelectDateWidget
 from django.contrib.auth import authenticate
 from django.contrib.auth import get_user_model
 from django.contrib.auth.forms import AuthenticationForm
-from django.utils.six import text_type
 from django.utils.translation import ugettext_lazy as _
 from django.conf import settings
 
@@ -185,7 +184,7 @@ class RegistrationForm(forms.Form):
         # This allows any number of security questions to be specified
         for index, question in enumerate(questions):
             self.fields["question_%s" % index] = forms.CharField(
-                label=_(text_type(question)),
+                label=question.title,
                 widget=forms.TextInput(
                     attrs=dict(
                         max_length=150,
@@ -482,7 +481,7 @@ class ForgotPasswordForm(forms.Form):
 
         for index, question in enumerate(questions):
             self.fields["question_%s" % index] = forms.CharField(
-                label=_(str(question)),
+                label=question.title,
                 widget=forms.TextInput(
                     attrs=dict(
                         required=True,

--- a/molo/profiles/views.py
+++ b/molo/profiles/views.py
@@ -66,10 +66,9 @@ class RegistrationView(FormView):
             self.request.site.root_page).live().filter(
             languages__language__is_main_language=True)
 
-        # create context dictionary with request for get_pages()
-        request = {"request": self.request}
+        context = {"request": self.request}
         self.translated_questions = get_pages(
-            request, self.questions, self.request.LANGUAGE_CODE)
+            context, self.questions, self.request.LANGUAGE_CODE)
         kwargs["questions"] = self.translated_questions
         kwargs["request"] = self.request
         return kwargs
@@ -270,10 +269,9 @@ class ForgotPasswordView(FormView):
             languages__language__is_main_language=True
         )
 
-        # create context dictionary with request for get_pages()
-        request = {"request": self.request}
+        context = {"request": self.request}
         translated_questions = get_pages(
-            request, self.security_questions, self.request.LANGUAGE_CODE
+            context, self.security_questions, self.request.LANGUAGE_CODE
         )
         kwargs["questions"] = translated_questions[
             :profile_settings.num_security_questions]

--- a/molo/profiles/views.py
+++ b/molo/profiles/views.py
@@ -276,7 +276,7 @@ class ForgotPasswordView(FormView):
         kwargs["questions"] = translated_questions[
             :profile_settings.num_security_questions]
         # limit security questions - done here because query in get_pages()
-        # cannot be performed once queryset is sliced
+        # cannot be performed once queryset is sliced into a list
         self.security_questions = self.security_questions[
             :profile_settings.num_security_questions]
         return kwargs


### PR DESCRIPTION
These questions are currently localised in 3 places:

- In view.get_form_kwargs() before they are passed to the form init
- Using the code in this commit
- In the template

The localisation in get_form_kwargs() gets translated pages but the other 2 options use the hardcoded translations in the application's locale.

I think for security questions admins will expect us to use the translation in the database, otherwise they will make a change in the admin interface and it won't be reflected in the interface.

That means that we can remove the localisation here. We can't remove the one in the template because that's also used for hardcoded strings like "Username" but it will be a no-op by the time the questions get there.