### PR TITLE
Ensure article is in articles list

### DIFF
--- a/molo/core/templatetags/core_tags.py
+++ b/molo/core/templatetags/core_tags.py
@@ -687,7 +687,7 @@ def get_next_article(context, article):
     locale_code = context.get('locale_code')
     section = article.get_parent_section()
     articles = load_child_articles_for_section(context, section, count=None)
-    if len(articles) > 1:
+    if len(articles) > 1 and article in articles:
         next_article = articles[articles.index(article) - 1]
     else:
         return None

--- a/molo/core/tests/test_template_tags.py
+++ b/molo/core/tests/test_template_tags.py
@@ -1,4 +1,4 @@
-# coding=utf-8
+# -*- coding: utf-8 -*-
 import pytest
 from django.test import TestCase, RequestFactory
 from mock import patch
@@ -11,8 +11,7 @@ from molo.core.templatetags.core_tags import (
 )
 
 
-@pytest.mark.django_db
-class TestModels(TestCase, MoloTestCaseMixin):
+class TestTemplateTags(TestCase, MoloTestCaseMixin):
 
     def setUp(self):
         self.mk_main()


### PR DESCRIPTION
Sometimes this doesn't happen which will cause a template exception

```
  File "/usr/local/lib/python2.7/site-packages/molo/core/templatetags/core_tags.py", line 691, in get_next_article
    next_article = articles[articles.index(article) - 1]
ValueError: <ArticlePage: Я и представить не могла, что на такое способна...> is not in list
```