### PR TITLE
Upgrade Sentry client (raven) to 6.5.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ install_requires = [
     'elastic-git',
     'markdown',
     'mote-prk==0.2.1',
-    'raven==5.0.0',
+    'raven==6.5.0',
     'redis',
     'requests',
     'setuptools>=18.5',


### PR DESCRIPTION
Version 5 is from 2014. Version 6 is technically a breaking change but I don't see any way that it will be incompatible with our usage of it.