### PR TITLE
Add template lint script

### DIFF
--- a/molo/core/scripts/template_lint.py
+++ b/molo/core/scripts/template_lint.py
@@ -1,0 +1,66 @@
+from __future__ import print_function
+
+from django.conf import settings
+from django.template import Template, TemplateSyntaxError
+
+from glob import glob
+
+from os import walk
+from os.path import join
+
+from sys import stderr
+
+
+def log_error(*args, **kwargs):
+    print(*args, file=stderr, **kwargs)
+
+
+def run():
+    exit_code = 0
+
+    html_templates = []
+    template_directories = [
+        walk_result[0] for walk_result in
+        walk(settings.PROJECT_ROOT)]
+
+    for directory in template_directories:
+        html_templates += glob(join(directory, '*.html'))
+
+    for filename in html_templates:
+        printable_filename = filename.replace(settings.PROJECT_ROOT, '')
+        items_loaded = []
+        errors = []
+        template_file = open(filename).read()
+
+        # Ensure that the template renders
+        Template(template_file)
+
+        lines = template_file.split("\n")
+
+        for line in lines:
+            if "{% load " in line:
+                items_loaded += [
+                    item for item in line.split(' ') if item not in [
+                        '{%', 'load', '', '%}']]
+
+        if len(items_loaded) != len(set(items_loaded)):
+            errors.append('Duplicate template tags loaded')
+            exit_code = 1
+
+        for load in items_loaded:
+            try:
+                padded_load = ' {0} '.format(load)
+                new_template_file = template_file.replace(padded_load, '')
+                Template(new_template_file)
+                errors.append('Can remove {0} without error'.format(load))
+                exit_code = 1
+            except TemplateSyntaxError:
+                pass
+
+        if errors:
+            log_error('')
+            log_error(printable_filename)
+            for error in errors:
+                log_error('  {0}'.format(error))
+
+    exit(exit_code)


### PR DESCRIPTION
Projects that depend on molo can use this as part of their build process to ensure that their templates are well-formed.

It's not completely bulletproof but it catches some things:

1) The templates all are parsed by Template() without error
2) There are no duplicate tag loads
3) All of the loads are used

I was surprised that after a bit of Googling I couldn't find a package to do this.

It's not a great solution but if it's buggy we can easily remove it.