### PR TITLE
Pin version of django-extensions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ install_requires = [
     'Django>=1.11,<2.0',
     'django-cas-ng==3.5.8',
     'django-el-pagination==3.1.0',
-    'django-extensions',
+    'django-extensions>=1,<2',
     'django-google-analytics-app==4.2.0',
     'django-libsass',
     'django-mptt==0.8.6',


### PR DESCRIPTION
Something in django-extensions 2 has changed which breaks our build. We should not use it yet.