### PR TITLE
Remove get_search_results

### DIFF
--- a/molo/profiles/admin_views.py
+++ b/molo/profiles/admin_views.py
@@ -1,4 +1,3 @@
-import uuid
 from wagtail.contrib.modeladmin.views import IndexView
 from wagtail.wagtailadmin import messages
 from django.utils.translation import ugettext as _
@@ -41,18 +40,3 @@ class FrontendUsersAdminView(IndexView):
 
     def get_template_names(self):
         return 'admin/frontend_users_admin_view.html'
-
-    def get_search_results(self, request, queryset, search_term):
-        """
-        Remove the (-) if we are searching for a valid UUID value
-        """
-        try:
-            uuid.UUID(search_term, version=4)
-            search_uuid = search_term.replace('-', '')
-            return super(FrontendUsersAdminView, self).get_search_results(
-                request, queryset, search_uuid)
-        except ValueError:
-            pass
-
-        return super(FrontendUsersAdminView, self).get_search_results(
-            request, queryset, search_term)

--- a/molo/profiles/tests/test_admin.py
+++ b/molo/profiles/tests/test_admin.py
@@ -198,19 +198,6 @@ class TestFrontendUsersAdminView(TestCase, MoloTestCaseMixin):
         )
         self.assertContains(response, self.user.profile.uuid)
 
-    def test_valid_uuid_search_on_admin(self):
-        response = self.client.get(
-            '/admin/auth/user/?q={0}'.format(self.user.profile.uuid)
-        )
-        self.assertContains(response, self.user)
-
-    def test_invalid_uuid_search_on_admin(self):
-        _, invalid_uuid = str(self.user.profile.uuid).split('-', 1)
-        response = self.client.get(
-            '/admin/auth/user/?q={0}'.format(invalid_uuid)
-        )
-        self.assertNotContains(response, self.user)
-
     @override_settings(CELERY_ALWAYS_EAGER=True)
     def test_export_csv_redirects(self):
         profile = self.user.profile


### PR DESCRIPTION
Since postgres has native uuid support we don't need to override the model admin `get_search_result`
however after removing this function searching for UUID in model admin won't work with sqlite