### PR TITLE
Remove wildcard ALLOWED_HOSTS in cookiecutter app

### DIFF
--- a/local_test_settings.py
+++ b/local_test_settings.py
@@ -1,6 +1,12 @@
 from testapp.settings.base import *  # noqa: F403, F405
 
 
+ALLOWED_HOSTS = [
+    'localhost',
+    '.localhost',
+    'site2',
+]
+
 ENABLE_SSO = True
 
 MIDDLEWARE_CLASSES += (  # noqa: F405

--- a/molo/core/cookiecutter/scaffold/{{cookiecutter.directory}}/{{cookiecutter.app_name}}/settings/base.py
+++ b/molo/core/cookiecutter/scaffold/{{cookiecutter.directory}}/{{cookiecutter.app_name}}/settings/base.py
@@ -32,7 +32,9 @@ SECRET_KEY = "{{cookiecutter.secret_key}}"
 DEBUG = True
 ENV = 'dev'
 
-ALLOWED_HOSTS = ['*']
+# List of hostnames which Django checks when serving your app, to
+# prevent against HTTP Host header attacks.
+ALLOWED_HOSTS = []
 
 
 # Base URL to use when referring to full URLs within the Wagtail admin

--- a/molo/core/cookiecutter/scaffold/{{cookiecutter.directory}}/{{cookiecutter.app_name}}/settings/dev.py
+++ b/molo/core/cookiecutter/scaffold/{{cookiecutter.directory}}/{{cookiecutter.app_name}}/settings/dev.py
@@ -5,6 +5,11 @@ DEBUG = True
 
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 
+ALLOWED_HOSTS = [
+    'localhost',
+    '.localhost',
+]
+
 try:
     from .local import *  # noqa
 except ImportError:


### PR DESCRIPTION
This is a security vulnerability which we shouldn't be encouraging. After creating a new app people are responsible for setting their allowed hosts correctly.