### PR TITLE
Fix datetime without timezone in celery tasks

### DIFF
--- a/molo/core/tasks.py
+++ b/molo/core/tasks.py
@@ -89,17 +89,17 @@ def clearsessions():
 @task(ignore_result=True)
 def demote_articles():
     ArticlePage.objects.live().filter(
-        featured_in_latest_end_date__lte=datetime.now()).update(
+        featured_in_latest_end_date__lte=timezone.now()).update(
             featured_in_latest=False,
             featured_in_latest_start_date=None,
             featured_in_latest_end_date=None)
     ArticlePage.objects.live().filter(
-        featured_in_section_end_date__lte=datetime.now()).update(
+        featured_in_section_end_date__lte=timezone.now()).update(
             featured_in_section=False,
             featured_in_section_start_date=None,
             featured_in_section_end_date=None)
     ArticlePage.objects.live().filter(
-        featured_in_homepage_end_date__lte=datetime.now()).update(
+        featured_in_homepage_end_date__lte=timezone.now()).update(
             featured_in_homepage=False,
             featured_in_homepage_start_date=None,
             featured_in_homepage_end_date=None)
@@ -108,13 +108,13 @@ def demote_articles():
 @task(ignore_result=True)
 def promote_articles():
     ArticlePage.objects.live().filter(
-        featured_in_latest_start_date__lte=datetime.now()).update(
+        featured_in_latest_start_date__lte=timezone.now()).update(
         featured_in_latest=True)
     ArticlePage.objects.live().filter(
-        featured_in_section_start_date__lte=datetime.now()).update(
+        featured_in_section_start_date__lte=timezone.now()).update(
         featured_in_section=True)
     ArticlePage.objects.live().filter(
-        featured_in_homepage_start_date__lte=datetime.now()).update(
+        featured_in_homepage_start_date__lte=timezone.now()).update(
         featured_in_homepage=True)
 
 
@@ -171,7 +171,7 @@ def rotate_latest(main_lang, index, main, site_settings, day):
                         # set random article to feature in latest
                         if random_article:
                             random_article.featured_in_latest_start_date = \
-                                datetime.now()
+                                timezone.now()
                             random_article.save_revision().publish()
                             promote_articles()
                             demote_last_featured_article()
@@ -214,7 +214,7 @@ def rotate_featured_in_homepage(main_lang, day, main):
                             if random_article:
                                 random_article. \
                                     featured_in_homepage_start_date = \
-                                    datetime.now()
+                                    timezone.now()
                                 random_article.save_revision().publish()
                                 promote_articles()
                                 demote_last_featured_article_in_homepage(


### PR DESCRIPTION
This causes warnings in the celery worker logs because newer versions of Django don't like naive datetimes (ones without timezones).

https://docs.djangoproject.com/en/1.11/topics/i18n/timezones/#interpretation-of-naive-datetime-objects

```
RuntimeWarning: DateTimeField ArticlePage.featured_in_section_end_date received a naive datetime (2018-05-09 15:00:02.701386) while time zone support is active.
```