### PR TITLE
Add is_via_bbm context to template tag

### DIFF
--- a/molo/core/templatetags/core_tags.py
+++ b/molo/core/templatetags/core_tags.py
@@ -664,6 +664,7 @@ def social_media_article(context, page=None):
         twitter = False
 
     data = {
+        'is_via_bbm': context['is_via_bbm'],
         'facebook': facebook,
         'twitter': twitter,
         'request': context['request'],


### PR DESCRIPTION
Template tags have a different context which means they need all the context variables to be passed in.