### PR TITLE
use getattr incase USE_QS_TRANSLATIONS setting attr is not defined

### DIFF
--- a/molo/core/templatetags/core_tags.py
+++ b/molo/core/templatetags/core_tags.py
@@ -40,7 +40,7 @@ def get_pages(context, queryset, locale):
         return list(queryset.live())
 
     pages = []
-    if settings.USE_QS_TRANSLATIONS:
+    if getattr(settings, 'USE_QS_TRANSLATIONS', None):
         pages = get_translations_for_pages(queryset, locale, request.site)
     else:
         show_only_translated_pages = SiteSettings.for_site(


### PR DESCRIPTION
use geattr in case the setting module does not have the USE_QS_TRANSLATIONS var defined
* we should not assume user defined/project specific attrs will always be available