### PR TITLE
update tagged articles core_tags

### DIFF
--- a/molo/core/templatetags/core_tags.py
+++ b/molo/core/templatetags/core_tags.py
@@ -358,7 +358,7 @@ def get_articles_for_tag(context, tag):
             context, ArticlePage.objects.descendant_of(
                 request.site.root_page).filter(
                 pk__in=pks).order_by(
-                'latest_revision_created_at'), locale)
+                '-first_published_at'), locale)
     return None
 
 


### PR DESCRIPTION
The last time @KaitCrawford  and I changed the ordering of the articles to `first_published_at` in the views file and it seemed to work locally and in production but recently it has been brought to our attention that only recent articles are being ordered, the older articles seem to be in more of  a jumbled order. I ran the tests and they are passing but that could be because the articles in the tests will all be new. I made a fix but I need your opinion on it: