### PR TITLE
Fix draft main language pages being displayed

### DIFF
--- a/molo/core/models.py
+++ b/molo/core/models.py
@@ -615,6 +615,8 @@ def get_translation_for(pages, locale, site, is_live=True):
                 translated_pages.append(translated)
             else:
                 if not show_only_translated_pages:
+                    if is_live is not None and not page.live:
+                        continue
                     translated_pages.append(page)
         except ObjectDoesNotExist:
             if not show_only_translated_pages:


### PR DESCRIPTION
This addresses a bug in the translations code. On sites that are set to show the main language page if a translated page doesn't exist the main language page is being displayed even if it is not published.
The correct behaviour (implemented in this PR) is to check if we only want live pages and then only return the page if it is live.