### PR TITLE
Make changes to the content API to allow navigating by tags.

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -11,7 +11,7 @@ plugin can be found on `GitHub <https://github.com/praekeltfoundation/molo.forms
 Articles
 --------
 
-A custom serializer is used to ensure that draft pages will also be
+A custom endpoint is used to ensure that draft pages will also be
 returned (this is required for the content import API).
 
 Pages endpoints
@@ -31,6 +31,9 @@ Custom fields::
 
 ``core.ArticlePage``
 ********************
+A special case is added to the ``MoloPageEndpoint``: If filtering with
+``?type=core.ArticlePage`` then the pages can also be filtered by the ``tag`` attribute
+of the ``nav_tags`` field using ``nav_tags__tag=<tag_id>``
 Custom fields::
 
     title, subtitle, body, tags, commenting_state, commenting_open_time,

--- a/molo/core/api/endpoints.py
+++ b/molo/core/api/endpoints.py
@@ -8,7 +8,7 @@ from wagtail.images.api.v2.endpoints import BaseAPIEndpoint
 
 from molo.core.models import (
     SiteLanguage,
-    Languages,
+    Languages, ArticlePage,
 )
 from molo.core.api.filters import MainLanguageFilter
 from molo.core.api.serializers import (
@@ -41,7 +41,7 @@ class MoloPagesEndpoint(PagesAPIEndpoint):
     ]
 
     known_query_parameters = PagesAPIEndpoint.known_query_parameters.union([
-        'is_main_language'
+        'is_main_language', 'nav_tags__tag'
     ])
     extra_api_fields = ['url', 'live']
 
@@ -70,6 +70,10 @@ class MoloPagesEndpoint(PagesAPIEndpoint):
         # Filter by site
         queryset = queryset.descendant_of(
             request.site.root_page, inclusive=True)
+
+        # Enable filtering by navigation tags
+        if model == ArticlePage and 'nav_tags__tag' in request.GET:
+            queryset = queryset.filter(nav_tags__tag=request.GET['nav_tags__tag'])
 
         return queryset
 

--- a/molo/core/api/endpoints.py
+++ b/molo/core/api/endpoints.py
@@ -73,7 +73,8 @@ class MoloPagesEndpoint(PagesAPIEndpoint):
 
         # Enable filtering by navigation tags
         if model == ArticlePage and 'nav_tags__tag' in request.GET:
-            queryset = queryset.filter(nav_tags__tag=request.GET['nav_tags__tag'])
+            queryset = queryset.filter(
+                nav_tags__tag=request.GET['nav_tags__tag'])
 
         return queryset
 

--- a/molo/core/api/endpoints.py
+++ b/molo/core/api/endpoints.py
@@ -73,8 +73,16 @@ class MoloPagesEndpoint(PagesAPIEndpoint):
 
         # Enable filtering by navigation tags
         if model == ArticlePage and 'nav_tags__tag' in request.GET:
-            queryset = queryset.filter(
-                nav_tags__tag=request.GET['nav_tags__tag'])
+            try:
+                queryset = queryset.filter(
+                    nav_tags__tag=request.GET['nav_tags__tag'])
+            except ValueError as e:
+                raise BadRequestError(
+                    "field filter error. '%s' is not a valid value "
+                    "for nav_tags__tag (%s)" % (
+                        request.GET['nav_tags__tag'],
+                        str(e)
+                    ))
 
         return queryset
 

--- a/molo/core/api/tests/test_views.py
+++ b/molo/core/api/tests/test_views.py
@@ -335,3 +335,22 @@ class PagesEndpointTestCase(APIMoloTestCase):
         obj = json.loads(response.content)
         self.assertEqual(obj['meta']['total_count'], 1)
         self.assertEqual(obj['items'][0]['title'], 'Test page 0')
+
+    def test_invalid_type_for_nav_tag_returns_error(self):
+        tag = self.mk_tag(self.tag_index)
+        ArticlePageTags.objects.create(page=self.article, tag=tag)
+
+        # Add a second, untagged article
+        self.mk_article(self.english_section, title='Second test page')
+
+        # Call the endpoint, filtering by the nav_tag
+        url = '/api/v2/pages/?type=core.ArticlePage&nav_tags__tag=b'
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 400)
+
+        # Check only the tagged article is present
+        obj = json.loads(response.content)
+        self.assertEqual(
+            obj['message'],
+            "field filter error. 'b' is not a valid value for nav_tags__tag"
+            " (invalid literal for int() with base 10: 'b')")

--- a/molo/core/api/tests/test_views.py
+++ b/molo/core/api/tests/test_views.py
@@ -327,7 +327,7 @@ class PagesEndpointTestCase(APIMoloTestCase):
 
         # Call the endpoint, filtering by the nav_tag
         url = '/api/v2/pages/?type=core.ArticlePage&nav_tags__tag={}'\
-                .format(tag.pk)
+            .format(tag.pk)
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
 

--- a/molo/core/models.py
+++ b/molo/core/models.py
@@ -1012,7 +1012,7 @@ class Tag(TranslatablePageMixin, MoloPage, ImportableMixin):
 
     api_fields = [
         "id", "title", "feature_in_homepage", "go_live_at",
-        "expire_at", "expired"
+        "expire_at", "expired", "live"
     ]
 
 


### PR DESCRIPTION
We want clients making use of the content API to be able to navigate the content via tags.
These changes allow us to filter out Tag pages that are not live.
They also allow us to filter ArticlePages based on the Tags attached to them.