### PR TITLE
Use a more lenient html parser and add more tests for block validation

### DIFF
--- a/molo/core/blocks.py
+++ b/molo/core/blocks.py
@@ -29,7 +29,7 @@ class MarkDownBlock(blocks.TextBlock):
         value = super().clean(value)
 
         # Return an error message if there is html in the value
-        has_html = bool(BeautifulSoup(value, "html.parser").find())
+        has_html = bool(BeautifulSoup(value, "lxml").find())
         if has_html:
             raise ValidationError(
                     _('Please use MarkDown for formatting text instead of '

--- a/molo/core/tests/test_blocks.py
+++ b/molo/core/tests/test_blocks.py
@@ -6,7 +6,25 @@ from molo.core.blocks import MarkDownBlock
 
 class TestMarkDownBlock(TestCase):
     def test_save_block_with_html_value_fails_validation(self):
+        # Test with some commonly used html tags
         block = MarkDownBlock()
         with (self.assertRaisesMessage(ValidationError,
               "Please use MarkDown for formatting text instead of HTML.")):
             block.clean(value="<b>Hello</b> There!")
+        with (self.assertRaisesMessage(ValidationError,
+              "Please use MarkDown for formatting text instead of HTML.")):
+            block.clean(value="<p>Hello There!</p>")
+        with (self.assertRaisesMessage(ValidationError,
+              "Please use MarkDown for formatting text instead of HTML.")):
+            block.clean(value='<a href="">Hello There!</a>')
+        with (self.assertRaisesMessage(ValidationError,
+              "Please use MarkDown for formatting text instead of HTML.")):
+            block.clean(value='<em>Hello There!</em>')
+        with (self.assertRaisesMessage(ValidationError,
+              "Please use MarkDown for formatting text instead of HTML.")):
+            block.clean(value='Hello There!<br>')
+
+        # Test that a commonly used but invalid tag is also caught
+        with (self.assertRaisesMessage(ValidationError,
+              "Please use MarkDown for formatting text instead of HTML.")):
+            block.clean(value="Hello There!</br>")


### PR DESCRIPTION
the `</br>` tag is often used in some of the springster content despite it not being a valid tag. We have to switch out to a more lenient parser to identify this tag and fail validation.

Added more tests as well.