### PR TITLE
Handle html in markdown content blocks

### DIFF
--- a/molo/core/blocks.py
+++ b/molo/core/blocks.py
@@ -1,3 +1,5 @@
+import html2markdown
+import re
 from bs4 import BeautifulSoup
 from django.utils.safestring import mark_safe
 from markdown import markdown
@@ -22,6 +24,42 @@ class MarkDownBlock(blocks.TextBlock):
             ],
         )
         return mark_safe(md)
+
+    def get_api_representation(self, value, context=None):
+        """
+        This identifies any content that contains html and converts it into
+        the quivalent markdown for sending via the API
+        """
+        # Remove an invalid html tag that is often present in the content
+        value = value.replace("</br>", "\n")
+
+        has_html = bool(BeautifulSoup(value, "html.parser").find())
+        if not has_html:
+            return self.get_prep_value(value)
+
+        # Some content has markdown and html. We convert it to html first
+        # to remove duplicate formatting and then to markdown
+        html_value = markdown(
+            value,
+            extensions=[
+                'markdown.extensions.fenced_code',
+                'codehilite',
+            ],
+        )
+        # This replaces newlines inside paragraphs with a space
+        html_value = re.sub(r'\n(?!<p>)', ' ', html_value)
+
+        markdown_value = html2markdown.convert(html_value)
+
+        # Remove any duplicated markdown
+        markdown_value = markdown_value.replace("____", "__")
+        markdown_value = markdown_value.replace("****", "**")
+        # Remove underlines since there isn't a markdown equivalent
+        markdown_value = markdown_value.replace("<u>", "")
+        markdown_value = markdown_value.replace("</u>", "")
+        # Remove any escape characters placed in front of markdown
+        markdown_value = markdown_value.replace("\\", "")
+        return markdown_value
 
 
 class MultimediaBlock(AbstractMediaChooserBlock):

--- a/molo/core/blocks.py
+++ b/molo/core/blocks.py
@@ -1,7 +1,5 @@
 from bs4 import BeautifulSoup
-from django.core.exceptions import ValidationError
 from django.utils.safestring import mark_safe
-from django.utils.translation import ugettext_lazy as _
 from markdown import markdown
 
 from wagtail.core import blocks
@@ -24,19 +22,6 @@ class MarkDownBlock(blocks.TextBlock):
             ],
         )
         return mark_safe(md)
-
-    def clean(self, value):
-        value = super().clean(value)
-
-        # Return an error message if there is html in the value
-        has_html = bool(BeautifulSoup(value, "lxml").find())
-        if has_html:
-            raise ValidationError(
-                    _('Please use MarkDown for formatting text instead of '
-                      'HTML.')
-                )
-
-        return value
 
 
 class MultimediaBlock(AbstractMediaChooserBlock):

--- a/molo/core/tests/test_blocks.py
+++ b/molo/core/tests/test_blocks.py
@@ -1,30 +1,7 @@
-from django.core.exceptions import ValidationError
 from django.test import TestCase
 
 from molo.core.blocks import MarkDownBlock
 
 
 class TestMarkDownBlock(TestCase):
-    def test_save_block_with_html_value_fails_validation(self):
-        # Test with some commonly used html tags
-        block = MarkDownBlock()
-        with (self.assertRaisesMessage(ValidationError,
-              "Please use MarkDown for formatting text instead of HTML.")):
-            block.clean(value="<b>Hello</b> There!")
-        with (self.assertRaisesMessage(ValidationError,
-              "Please use MarkDown for formatting text instead of HTML.")):
-            block.clean(value="<p>Hello There!</p>")
-        with (self.assertRaisesMessage(ValidationError,
-              "Please use MarkDown for formatting text instead of HTML.")):
-            block.clean(value='<a href="">Hello There!</a>')
-        with (self.assertRaisesMessage(ValidationError,
-              "Please use MarkDown for formatting text instead of HTML.")):
-            block.clean(value='<em>Hello There!</em>')
-        with (self.assertRaisesMessage(ValidationError,
-              "Please use MarkDown for formatting text instead of HTML.")):
-            block.clean(value='Hello There!<br>')
-
-        # Test that a commonly used but invalid tag is also caught
-        with (self.assertRaisesMessage(ValidationError,
-              "Please use MarkDown for formatting text instead of HTML.")):
-            block.clean(value="Hello There!</br>")
+    

--- a/molo/core/tests/test_blocks.py
+++ b/molo/core/tests/test_blocks.py
@@ -4,4 +4,35 @@ from molo.core.blocks import MarkDownBlock
 
 
 class TestMarkDownBlock(TestCase):
-    
+    def test_get_api_rep_converts_html_to_markdown(self):
+        # Test with some commonly used html tags
+        block = MarkDownBlock()
+        self.assertEqual(
+            block.get_api_representation(value="<b>Hello</b> There!"),
+            "__Hello__ There!")
+        self.assertEqual(
+            block.get_api_representation(value="<b>**Hello**</b> There!"),
+            "__Hello__ There!")
+        self.assertEqual(
+            block.get_api_representation(value="<p>Hello\nThere!</p>"),
+            "Hello There!")
+        self.assertEqual(
+            block.get_api_representation(value="**Hello**<br/>There!"),
+            "__Hello__  \nThere!")
+        self.assertEqual(
+            block.get_api_representation(value="<u>Hello</u> There!"),
+            "Hello There!")
+        self.assertEqual(
+            block.get_api_representation(
+                value="<ul><li>Hello</li>\n<li>There!</li></ul>"),
+            "*   Hello\n *   There!")
+        self.assertEqual(
+            block.get_api_representation(
+                value="<p>Hello</p>\n\n<p>There!</p>"),
+            "Hello\n\nThere!")
+        self.assertEqual(
+            block.get_api_representation(value='<a href="Hello">There!</a>'),
+            "[There!](Hello)")
+        self.assertEqual(
+            block.get_api_representation(value="<em>#Hello There!</em>"),
+            "_#Hello There!_")

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,7 @@ install_requires = [
     'django-prometheus',
     'prometheus_client',
     'django-enumfield==1.5',
+    'html2markdown',
 ]
 
 # we need to only install typing for python2


### PR DESCRIPTION
Markdown blocks are used in the body of ArticlePages. They accept html and markdown content as their value. However we only want to use one formatting type when sendin the content via th API.

Therefore, this PR removes the validation that prevents html from being added to the content. It also overwrites the api representation of the block to convert any html content to purely markdown before sending it via the API.