### PR TITLE
Fix main and index delete

### DIFF
--- a/molo/core/tests/wagtail_hooks/test_delete_page_translations.py
+++ b/molo/core/tests/wagtail_hooks/test_delete_page_translations.py
@@ -27,7 +27,7 @@ class TestHookDeletePageTranslations(TestCase, MoloTestCaseMixin):
 
         self.login()
 
-        self.page_english = self.mk_article(self.main, title='En')
+        self.page_english = self.mk_article(self.section_index, title='En')
 
         self.page_xhosa = self.mk_article_translation(
             self.page_english, xhosa, title='Xh')
@@ -62,3 +62,19 @@ class TestHookDeletePageTranslations(TestCase, MoloTestCaseMixin):
         self.assertEqual(ArticlePage.objects.filter(title='Xh').count(), 1)
         self.assertEqual(ArticlePage.objects.get(
                 title='En').translated_pages.all().count(), 1)
+
+    def test_deletes_main_page_and_all_children(self):
+        response = self.client.post(
+            '/admin/pages/{0}/delete/'.format(self.main.id))
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(ArticlePage.objects.filter(title='En').count(), 0)
+        self.assertEqual(ArticlePage.objects.filter(title='Xh').count(), 0)
+        self.assertEqual(ArticlePage.objects.filter(title='Zu').count(), 0)
+
+    def test_deletes_index_page_and_all_children(self):
+        response = self.client.post(
+            '/admin/pages/{0}/delete/'.format(self.section_index.pk))
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(ArticlePage.objects.filter(title='En').count(), 0)
+        self.assertEqual(ArticlePage.objects.filter(title='Xh').count(), 0)
+        self.assertEqual(ArticlePage.objects.filter(title='Zu').count(), 0)

--- a/molo/core/wagtail_hooks.py
+++ b/molo/core/wagtail_hooks.py
@@ -73,7 +73,10 @@ def copy_translation_pages_hook(request, page, new_page):
 
 @hooks.register('before_delete_page')
 def delete_page_translations(request, page):
-    if request.method == 'POST' and page.specific.language.is_main_language:
+    # If this is the main language page then we want to delete all translations
+    # but Main and Index pages don't have a language or translations
+    if request.method == 'POST' and hasattr(page.specific, 'language') and \
+            page.specific.language.is_main_language:
         for translation in page.specific.translated_pages.all():
             translation.delete()
 


### PR DESCRIPTION
Currently when you try to delete a Main or Index page a 500 error is raised.
This is because these pages don't have a language attribute.