### PR TITLE
update migrations

### DIFF
--- a/molo/core/migrations/0001_squashed_0077_molo_page.py
+++ b/molo/core/migrations/0001_squashed_0077_molo_page.py
@@ -571,6 +571,8 @@ class Migration(migrations.Migration):
     initial = True
 
     dependencies = [
+        ('wagtailcore', '0043_lock_fields'),
+        ('wagtailcore', '0052_pagelogentry'),
         ('wagtailcore', '0015_add_more_verbose_names'),
         ('wagtailmedia', '0003_copy_media_permissions_to_collections'),
         ('wagtailimages', '0005_make_filter_spec_unique'),

--- a/molo/core/migrations/0001_squashed_0077_molo_page.py
+++ b/molo/core/migrations/0001_squashed_0077_molo_page.py
@@ -593,6 +593,8 @@ class Migration(migrations.Migration):
         ('wagtailcore', '0024_alter_page_content_type_on_delete_behaviour'),
         ('wagtailadmin', '0001_create_admin_access_permissions'),
         ('wagtailimages', '0018_remove_rendition_filter'),
+        ('wagtailcore', '0043_lock_fields'),
+        ('wagtailcore', '0052_pagelogentry'),
     ]
 
     operations = [

--- a/molo/core/migrations/0001_squashed_0077_molo_page.py
+++ b/molo/core/migrations/0001_squashed_0077_molo_page.py
@@ -571,8 +571,6 @@ class Migration(migrations.Migration):
     initial = True
 
     dependencies = [
-        ('wagtailcore', '0043_lock_fields'),
-        ('wagtailcore', '0052_pagelogentry'),
         ('wagtailcore', '0015_add_more_verbose_names'),
         ('wagtailmedia', '0003_copy_media_permissions_to_collections'),
         ('wagtailimages', '0005_make_filter_spec_unique'),

--- a/molo/core/migrations/0001_squashed_0077_molo_page.py
+++ b/molo/core/migrations/0001_squashed_0077_molo_page.py
@@ -571,6 +571,8 @@ class Migration(migrations.Migration):
     initial = True
 
     dependencies = [
+        ('wagtailcore', '0043_lock_fields'),
+        ('wagtailcore', '0052_pagelogentry'),
         ('wagtailcore', '0015_add_more_verbose_names'),
         ('wagtailmedia', '0003_copy_media_permissions_to_collections'),
         ('wagtailimages', '0005_make_filter_spec_unique'),
@@ -593,8 +595,6 @@ class Migration(migrations.Migration):
         ('wagtailcore', '0024_alter_page_content_type_on_delete_behaviour'),
         ('wagtailadmin', '0001_create_admin_access_permissions'),
         ('wagtailimages', '0018_remove_rendition_filter'),
-        ('wagtailcore', '0043_lock_fields'),
-        ('wagtailcore', '0052_pagelogentry'),
     ]
 
     operations = [

--- a/molo/core/migrations/0023_run_wagtail_migrations_first.py
+++ b/molo/core/migrations/0023_run_wagtail_migrations_first.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+from django.core.management.sql import emit_pre_migrate_signal
+
+
+def run_wagtail_migration_before_core(apps, schema_editor):
+    db_alias = schema_editor.connection.alias
+    emit_pre_migrate_signal(verbosity=2, interactive=False, db=db_alias)
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('wagtailcore', '0052_pagelogentry'),
+        ('core', '0022_auto_20201215_0734'),
+        ('core', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.RunPython(run_wagtail_migration_before_core),
+    ]

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -5936,9 +5936,9 @@
       }
     },
     "marked": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.4.0.tgz",
-      "integrity": "sha512-tMsdNBgOsrUophCAFQl0XPe6Zqk/uy9gnue+jIIKhykO51hxyu6uNx7zBPy0+y/WKYVZZMspV9YeXLNdKk+iYw=="
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.7.0.tgz",
+      "integrity": "sha512-c+yYdCZJQrsRjTPhUx7VKkApw9bwDkNbHUKo1ovgcfDjb2kc8rLuRbIFyXL5WOEUwzSSKo3IXpph2K6DqB/KZg=="
     },
     "marked-terminal": {
       "version": "3.3.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "gulpfile.js",
   "dependencies": {
     "electron": "^7.2.4",
-    "marked": "^0.4.0",
+    "marked": "^0.7.0",
     "axios": "^0.21.1",
     "postcss": "^7.0.0"
   },


### PR DESCRIPTION
The 0001 squashed migration requires wagtail 0052 to run, adding a new migration that runs the wagtail migration first and works for both new and existing databases